### PR TITLE
pool constructor remove redundant port assigment

### DIFF
--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -32,7 +32,6 @@ class Pgtk::Pool
   def initialize(host: 'localhost', port:, dbname:, user:, password:)
     @host = host
     @port = port
-    @port = port
     @dbname = dbname
     @user = user
     @password = password


### PR DESCRIPTION
Hello!

Just exploring your gem and noticed some redundant line of code. Do we need issue for things like this?