### PR TITLE
#262: add option `--locale=en_US.UTF-8` to `initdb`

### DIFF
--- a/lib/pgtk/pgsql_task.rb
+++ b/lib/pgtk/pgsql_task.rb
@@ -183,6 +183,7 @@ class Pgtk::PgsqlTask < Rake::TaskLib
         [
           'initdb',
           '--auth=trust',
+          '--locale=en_US.UTF-8',
           '-D',
           Shellwords.escape(home),
           '--username',


### PR DESCRIPTION
Closes #262 