### PR TITLE
Fix #217: stop deriving fake_config id from microsecond timestamp

### DIFF
--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -42,9 +42,8 @@ require_relative '../lib/pgtk/liquibase_task'
 require_relative '../lib/pgtk/pgsql_task'
 
 class Pgtk::Test < Minitest::Test
-  def fake_config
+  def fake_config(id: Integer(Time.now.strftime('%s%6N'), 10) % 1_000_000)
     Dir.mktmpdir do |dir|
-      id = Integer(Time.now.strftime('%s%6N'), 10) % 1_000_000
       f = File.join(dir, 'cfg.yml')
       Pgtk::PgsqlTask.new("pgsql#{id}") do |t|
         t.dir = File.join(dir, 'pgsql')

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -37,15 +37,18 @@ require 'logger'
 require 'loog'
 require 'rake'
 require 'rake/tasklib'
+require 'securerandom'
 require_relative '../lib/pgtk'
 require_relative '../lib/pgtk/liquibase_task'
 require_relative '../lib/pgtk/pgsql_task'
 
 class Pgtk::Test < Minitest::Test
-  def fake_config(id: Integer(Time.now.strftime('%s%6N'), 10) % 1_000_000)
+  def fake_config(id: SecureRandom.hex(8))
     Dir.mktmpdir do |dir|
       f = File.join(dir, 'cfg.yml')
-      Pgtk::PgsqlTask.new("pgsql#{id}") do |t|
+      pgsql = "pgsql#{id}"
+      Rake::Task[pgsql].clear if Rake::Task.task_defined?(pgsql)
+      Pgtk::PgsqlTask.new(pgsql) do |t|
         t.dir = File.join(dir, 'pgsql')
         t.user = 'hello'
         t.password = 'A B C привет ! & | !'
@@ -53,13 +56,17 @@ class Pgtk::Test < Minitest::Test
         t.yaml = f
         t.quiet = true
       end
-      Rake::Task["pgsql#{id}"].invoke
-      Pgtk::LiquibaseTask.new("liquibase#{id}") do |t|
+      Rake::Task[pgsql].reenable
+      Rake::Task[pgsql].invoke
+      lb = "liquibase#{id}"
+      Rake::Task[lb].clear if Rake::Task.task_defined?(lb)
+      Pgtk::LiquibaseTask.new(lb) do |t|
         t.master = File.join(__dir__, '../test-resources/master.xml')
         t.yaml = f
         t.quiet = true
       end
-      Rake::Task["liquibase#{id}"].invoke
+      Rake::Task[lb].reenable
+      Rake::Task[lb].invoke
       assert_path_exists(f)
       yield(f)
     end

--- a/test/test_fake_config.rb
+++ b/test/test_fake_config.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rake'
+require_relative 'test__helper'
+
+# Tests for the +fake_config+ helper itself.
+#
+# This regression suite documents the root cause of the flakiness reported
+# in https://github.com/yegor256/pgtk/issues/217. The helper used to derive
+# the Rake task name from a microsecond-resolution timestamp, which can
+# collide between two tests in the same process. When the names collide,
+# the second +Rake::Task#invoke+ becomes a no-op (because +@already_invoked+
+# is already +true+) and the YAML config file is silently never created,
+# causing +assert_path_exists+ inside +fake_config+ to fail.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+# License:: MIT
+class TestFakeConfig < Pgtk::Test
+  def test_creates_yaml_when_called_twice_with_same_id
+    id = "fixed_#{rand(1_000_000)}"
+    fake_config(id: id) { |f| assert_path_exists(f) }
+    fake_config(id: id) { |f| assert_path_exists(f) }
+  end
+end


### PR DESCRIPTION
@yegor256 this PR fixes #217 — the flaky `test_doesnt_shadow_larger_timeout` failure with the message:

```
Expected path '/tmp/d20251110-2777-peflke/cfg.yml' to exist.
```

## Root cause

`Pgtk::Test#fake_config` derives the Rake task name from the current time:

```ruby
id = Integer(Time.now.strftime('%s%6N'), 10) % 1_000_000
```

That's just the microsecond component. Two consecutive `fake_config` calls in the same process can collide, and when they do, the second `Rake::Task#invoke` becomes a no-op (because `@already_invoked` is already `true`). The YAML config file is therefore never created and `assert_path_exists(f)` inside `fake_config` fails — exactly the symptom shown in the issue.

The collision is microsecond-rare per pair of tests, but with thousands of CI runs it surfaces once in a while.

## Fix

* Use `SecureRandom.hex(8)` for the id, so it never collides in practice.
* As a belt-and-suspenders, clear and re-enable the Rake task before invoking it, so an explicitly reused id (e.g. in a regression test) still works.

## Test

Added `test/test_fake_config.rb` with a regression test that calls `fake_config(id: same_id)` twice and asserts both succeed. With the old helper this fails with the exact error from the issue; with the patch it passes.

## CI

All 10 CI checks are green (markdown-lint, typos, pdd, xcop, rake on ubuntu-24.04 / Ruby 3.3, yamllint, actionlint, copyrights, reuse, docker).