### PR TITLE
Fix #343: align Retry with docs and add backoff on PG::ConnectionBad

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ retry_pool.exec('INSERT INTO logs (message) VALUES ($1)', ['User logged in'])
 Key features:
 
 1. Only `SELECT` queries are retried (to prevent duplicate data modifications)
-2. Retries happen immediately, except when the underlying error is `PG::ConnectionBad`,
-in which case an exponential backoff (50ms, 200ms, 1s) is applied between attempts to
-avoid amplifying upstream login-failure storms
+2. Retries happen immediately, except on `PG::ConnectionBad`,
+   where an exponential backoff (50ms, 200ms, 1s) is applied
+   between attempts to avoid amplifying upstream login storms
 3. The original error is raised after all retry attempts are exhausted
 4. Works seamlessly with other decorators like `Pgtk::Spy` and `Pgtk::Impatient`
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ retry_pool.exec('INSERT INTO logs (message) VALUES ($1)', ['User logged in'])
 Key features:
 
 1. Only `SELECT` queries are retried (to prevent duplicate data modifications)
-2. Retries happen immediately without delay
+2. Retries happen immediately, except when the underlying error is `PG::ConnectionBad`,
+in which case an exponential backoff (50ms, 200ms, 1s) is applied between attempts to
+avoid amplifying upstream login-failure storms
 3. The original error is raised after all retry attempts are exhausted
 4. Works seamlessly with other decorators like `Pgtk::Spy` and `Pgtk::Impatient`
 

--- a/lib/pgtk/retry.rb
+++ b/lib/pgtk/retry.rb
@@ -54,6 +54,8 @@ class Pgtk::Retry
   # so its message and stack trace are preserved for debugging.
   class Exhausted < StandardError; end
 
+  BACKOFFS = [0.05, 0.2, 1.0].freeze
+
   # Constructor.
   #
   # @param [Pgtk::Pool] pool The pool to decorate
@@ -86,13 +88,15 @@ class Pgtk::Retry
   end
 
   # Execute a SQL query with automatic retry on transient failures.
-  # SELECT queries are retried on any error, since reads are idempotent.
-  # Non-SELECT queries are retried only on PG::ConnectionBad, since by
-  # definition the query never reached the server, so retrying cannot
-  # duplicate a write. Other errors on writes propagate immediately,
-  # because a failure may occur after the server received the query but
-  # before the acknowledgement reached the client, and retrying a
-  # non-idempotent write could duplicate it.
+  # Only SELECT queries are retried, since reads are idempotent.
+  # Non-SELECT queries propagate the original error immediately, even
+  # on PG::ConnectionBad, because that error can be raised after the
+  # server already received the query but before the acknowledgement
+  # reached the client, and retrying a non-idempotent write could
+  # duplicate it. When the underlying error is PG::ConnectionBad, an
+  # exponential backoff (see BACKOFFS) is applied between attempts, so
+  # that a SELECT failing against an upstream pool that is in its
+  # login-failure cache window does not amplify the storm.
   #
   # @param [String] sql The SQL query with params inside (possibly)
   # @return [Array] Result rows
@@ -101,14 +105,11 @@ class Pgtk::Retry
     attempt = 0
     begin
       @pool.exec(sql, *)
-    rescue PG::ConnectionBad => e
-      attempt += 1
-      raise(Exhausted, "Retry gave up after #{@attempts} attempts: #{e.message}") if attempt >= @attempts
-      retry
     rescue StandardError, Pgtk::Impatient::TooSlow => e
       raise(e) unless query.strip.upcase.start_with?('SELECT')
       attempt += 1
       raise(Exhausted, "Retry gave up after #{@attempts} attempts: #{e.message}") if attempt >= @attempts
+      sleep(BACKOFFS[attempt - 1] || BACKOFFS.last) if e.is_a?(PG::ConnectionBad)
       retry
     end
   end

--- a/test/test_liquicheck_task.rb
+++ b/test/test_liquicheck_task.rb
@@ -84,7 +84,7 @@ class TestLiquicheckTask < Pgtk::Test
         /004-some-migration.xml.+\n.+ID "00-test" is not the beginning of a logicalFilePath "004-some-migration.xml"/,
         out
       )
-      assert_match(/005-some-migration.xml.+\n.+ID "005" has not suffix/, out)
+      assert_match(/005-some-migration.xml.+\n.+ID "005" has no suffix/, out)
       assert_match(
         /006-some-migration.xml.+\n.+logicalFilePath\s
         "006-other-migration.xml"\sdoes\snot\sequal\sthe\sxml\sfile\sname\s"006-some-migration.xml"/x,

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -241,60 +241,6 @@ class TestRetry < Pgtk::Test
     end
   end
 
-  def test_retries_insert_on_connection_bad
-    fake_pool do |pool|
-      counter = 0
-      stub = Object.new
-      def stub.version
-        'stub'
-      end
-      stub.define_singleton_method(:exec) do |sql, *args|
-        counter += 1
-        raise(PG::ConnectionBad, 'SSL error: decryption failed') if counter < 2
-        pool.exec(sql, *args)
-      end
-      retrier = Pgtk::Retry.new(stub, attempts: 3)
-      retrier.exec('INSERT INTO book (title) VALUES ($1)', ['Connection Test'])
-      assert_equal(2, counter, 'insert must be retried on PG::ConnectionBad since the query never reached the server')
-    end
-  end
-
-  def test_retries_update_on_connection_bad
-    fake_pool do |pool|
-      counter = 0
-      stub = Object.new
-      def stub.version
-        'stub'
-      end
-      stub.define_singleton_method(:exec) do |sql, *args|
-        counter += 1
-        raise(PG::ConnectionBad, 'SSL error: bad record mac') if counter < 2
-        pool.exec(sql, *args)
-      end
-      retrier = Pgtk::Retry.new(stub, attempts: 3)
-      retrier.exec('UPDATE book SET title = $1 WHERE id = $2', ['Updated', 1])
-      assert_equal(2, counter, 'update must be retried on PG::ConnectionBad')
-    end
-  end
-
-  def test_retries_set_on_connection_bad
-    fake_pool do |pool|
-      counter = 0
-      stub = Object.new
-      def stub.version
-        'stub'
-      end
-      stub.define_singleton_method(:exec) do |sql, *args|
-        counter += 1
-        raise(PG::ConnectionBad, 'PQconsumeInput() SSL error') if counter < 2
-        pool.exec(sql, *args)
-      end
-      retrier = Pgtk::Retry.new(stub, attempts: 3)
-      retrier.exec("SET statement_timeout = '15s'")
-      assert_equal(2, counter, 'SET must be retried on PG::ConnectionBad')
-    end
-  end
-
   def test_retries_select_on_too_slow
     fake_pool do |pool|
       counter = 0
@@ -349,27 +295,6 @@ class TestRetry < Pgtk::Test
     end
   end
 
-  def test_fails_insert_after_max_connection_bad_attempts
-    fake_pool do |_pool|
-      counter = 0
-      stub = Object.new
-      def stub.version
-        'stub'
-      end
-      stub.define_singleton_method(:exec) do |_sql, *_args|
-        counter += 1
-        raise(PG::ConnectionBad, 'Persistent connection failure')
-      end
-      retrier = Pgtk::Retry.new(stub, attempts: 3)
-      e =
-        assert_raises(Pgtk::Retry::Exhausted) do
-          retrier.exec('INSERT INTO book (title) VALUES ($1)', ['Fail Test'])
-        end
-      assert_kind_of(PG::ConnectionBad, e.cause, 'original PG::ConnectionBad must be preserved as cause')
-      assert_equal(3, counter, 'insert must be retried up to the configured limit on PG::ConnectionBad')
-    end
-  end
-
   def test_does_not_retry_non_select_on_connection_bad
     fake_pool do |_pool|
       counter = 0
@@ -385,7 +310,10 @@ class TestRetry < Pgtk::Test
       assert_raises(PG::ConnectionBad) do
         retrier.exec('INSERT INTO book (title) VALUES ($1)', ['No Retry'])
       end
-      assert_equal(1, counter, 'non-SELECT must not be retried on PG::ConnectionBad, since the response may be lost after the server received the query')
+      assert_equal(
+        1, counter,
+        'non-SELECT must not be retried on PG::ConnectionBad: the response may be lost after the server got the query'
+      )
     end
   end
 end

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -369,4 +369,23 @@ class TestRetry < Pgtk::Test
       assert_equal(3, counter, 'insert must be retried up to the configured limit on PG::ConnectionBad')
     end
   end
+
+  def test_does_not_retry_non_select_on_connection_bad
+    fake_pool do |_pool|
+      counter = 0
+      stub = Object.new
+      def stub.version
+        'stub'
+      end
+      stub.define_singleton_method(:exec) do |_sql, *_args|
+        counter += 1
+        raise(PG::ConnectionBad, 'server closed the connection unexpectedly')
+      end
+      retrier = Pgtk::Retry.new(stub, attempts: 3)
+      assert_raises(PG::ConnectionBad) do
+        retrier.exec('INSERT INTO book (title) VALUES ($1)', ['No Retry'])
+      end
+      assert_equal(1, counter, 'non-SELECT must not be retried on PG::ConnectionBad, since the response may be lost after the server received the query')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes #343.

- **Root cause:** the standalone `rescue PG::ConnectionBad` clause in `Retry#exec` retried unconditionally for *all* query types, contradicting the class docstring and README (which both state non-SELECT queries are not retried) and amplifying login-failure storms when the upstream pool was in its `FATAL`-cache window.
- **Symptom 1 fix:** drop the standalone `rescue PG::ConnectionBad` clause, so non-SELECT queries propagate the original error immediately on connection loss too. This is the safe stance documented in the class header — `PG::ConnectionBad` can be raised after the server received the query but before the ack reached the client, so retrying a non-idempotent write could duplicate it.
- **Symptom 2 fix:** when a SELECT retry is triggered by `PG::ConnectionBad`, sleep an exponential 50ms / 200ms / 1s between attempts (`BACKOFFS`) to stop hammering the upstream during its login-failure cache window.
- Method docstring and README updated to match. Tests asserting the now-removed behavior were dropped; a new test `test_does_not_retry_non_select_on_connection_bad` pins the documented contract.

The branch also includes a tiny baseline-fix commit aligning a stale regex in `test/test_liquicheck_task.rb` with the error message updated in 51fea24's predecessor (`e14362f`), which was blocking a green build.

## Test plan

- [x] `bundle exec rake` is green (100 tests, 0 failures, RuboCop clean)
- [x] New test `test_does_not_retry_non_select_on_connection_bad` fails on master and passes on this branch
- [x] Existing SELECT retry behavior preserved (verified by `test_retries_select_on_failure`, `test_retries_select_on_too_slow`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)