### PR TITLE
Fix #347: validate each connection in Pool#start! to fail fast on born-sick sockets

### DIFF
--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -100,12 +100,15 @@ class Pgtk::Pool
     @max.times do
       @pool.push(@wire.connection)
     end
-    @started = true
     (2 * @max).times do
       connect { |c| c.exec('SELECT 1') }
     rescue StandardError => e
-      @log.warn("Pool warm-up query failed, slot was renewed: #{e.message.strip}")
+      @log.warn("Pool warm-up query failed, slot will be retried: #{e.message.strip}")
     end
+    @max.times do
+      connect { |c| c.exec('SELECT 1') }
+    end
+    @started = true
     @log.debug("PostgreSQL pool started with #{@max} connections")
   end
 

--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -101,6 +101,11 @@ class Pgtk::Pool
       @pool.push(@wire.connection)
     end
     @started = true
+    (2 * @max).times do
+      connect { |c| c.exec('SELECT 1') }
+    rescue StandardError => e
+      @log.warn("Pool warm-up query failed, slot was renewed: #{e.message.strip}")
+    end
     @log.debug("PostgreSQL pool started with #{@max} connections")
   end
 

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -375,6 +375,24 @@ class TestPool < Pgtk::Test
     end
   end
 
+  def test_fails_fast_when_start_cannot_heal_a_persistently_broken_pool
+    fake_config do |f|
+      real = Pgtk::Wire::Yaml.new(f)
+      poison = Object.new
+      poison.define_singleton_method(:connection) do
+        conn = real.connection
+        conn.define_singleton_method(:exec) do |*_a, &_b|
+          raise(PG::ConnectionBad, 'persistently broken connection')
+        end
+        conn
+      end
+      pool = Pgtk::Pool.new(poison, max: 1, log: Loog::NULL)
+      assert_raises(PG::ConnectionBad, 'start! must raise when warm-up cannot make a slot healthy') do
+        pool.start!
+      end
+    end
+  end
+
   def test_reconnects_on_pg_reboot
     port = RandomPort::Pool::SINGLETON.acquire
     Dir.mktmpdir do |dir|

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -364,12 +364,13 @@ class TestPool < Pgtk::Test
       pool = Pgtk::Pool.new(flaky, max: 2, log: Loog::NULL)
       pool.start!
       items = pool.instance_variable_get(:@pool).instance_variable_get(:@items)
-      ok = items.all? do |c|
-        c.exec('SELECT 1')
-        true
-      rescue StandardError
-        false
-      end
+      ok =
+        items.all? do |c|
+          c.exec('SELECT 1')
+          true
+        rescue StandardError
+          false
+        end
       assert(ok, 'start! must validate each pool slot so born-sick connections never linger')
     end
   end

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -346,6 +346,34 @@ class TestPool < Pgtk::Test
     end
   end
 
+  def test_validates_each_connection_during_start_to_replace_born_sick_slots
+    fake_config do |f|
+      real = Pgtk::Wire::Yaml.new(f)
+      calls = 0
+      flaky = Object.new
+      flaky.define_singleton_method(:connection) do
+        conn = real.connection
+        calls += 1
+        if calls <= 2
+          conn.define_singleton_method(:exec) do |*_a, &_b|
+            raise(PG::ConnectionBad, 'simulated born-sick connection')
+          end
+        end
+        conn
+      end
+      pool = Pgtk::Pool.new(flaky, max: 2, log: Loog::NULL)
+      pool.start!
+      items = pool.instance_variable_get(:@pool).instance_variable_get(:@items)
+      ok = items.all? do |c|
+        c.exec('SELECT 1')
+        true
+      rescue StandardError
+        false
+      end
+      assert(ok, 'start! must validate each pool slot so born-sick connections never linger')
+    end
+  end
+
   def test_reconnects_on_pg_reboot
     port = RandomPort::Pool::SINGLETON.acquire
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
Closes #347. Pool#start! now exercises every slot it just opened with a cheap SELECT 1 round-trip, going through the existing connect/renew machinery so any connection that completes its handshake but is broken from birth gets renewed in-line before start! returns. The loop runs 2 * @max times because the IterableQueue is FIFO and a single pass can leave a freshly-renewed slot untested. This eliminates the case where the first user query after startup hits a born-sick connection (e.g., an SSL session whose state is corrupt before the first round-trip on managed PostgreSQL behind TLS-terminating networks).