### PR TITLE
Fix #351: forward extra opts to PG.connect; honor URL query in Wire::Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,31 @@ variable `DATABASE_URL`, formatted like
 pgsql = Pgtk::Pool.new(Pgtk::Wire::Env.new)
 ```
 
+Both `Pgtk::Wire::Direct` and `Pgtk::Wire::Env` accept extra keyword
+arguments and forward them to `PG.connect`, so any
+[libpq parameter](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS)
+can be passed through (`sslmode`, `connect_timeout`, `keepalives`,
+`keepalives_idle`, `application_name`, and so on):
+
+```ruby
+Pgtk::Wire::Direct.new(
+  host: 'db.example.com', port: 5432, dbname: 'app',
+  user: 'u', password: 'p',
+  sslmode: 'require', connect_timeout: 5, keepalives: 1
+)
+Pgtk::Wire::Env.new('DATABASE_URL', sslmode: 'require', keepalives: 1)
+```
+
+`Pgtk::Wire::Env` also honors the URL query string, so options can be
+configured from the environment alone:
+
+```text
+DATABASE_URL=postgres://u:p@h:5432/d?sslmode=require&keepalives=1&keepalives_idle=30
+```
+
+Explicit keyword arguments win over options carried in the URL query string
+on conflict.
+
 Now you can fetch some data from the DB:
 
 ```ruby

--- a/lib/pgtk/wire.rb
+++ b/lib/pgtk/wire.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'cgi'
 require 'pg'
 require 'uri'
 require 'yaml'

--- a/lib/pgtk/wire.rb
+++ b/lib/pgtk/wire.rb
@@ -25,7 +25,9 @@ module Pgtk::Wire
     # @param [String] dbname Database name
     # @param [String] user Username
     # @param [String] password Password
-    def initialize(host:, port:, dbname:, user:, password:)
+    # @param [Hash] opts Extra options forwarded to +PG.connect+ (e.g. +sslmode+,
+    #   +connect_timeout+, +keepalives+, +keepalives_idle+, +application_name+)
+    def initialize(host:, port:, dbname:, user:, password:, **opts)
       raise(ArgumentError, "The host can't be nil") if host.nil?
       @host = host
       raise(ArgumentError, "The port can't be nil") if port.nil?
@@ -33,11 +35,12 @@ module Pgtk::Wire
       @dbname = dbname
       @user = user
       @password = password
+      @opts = opts
     end
 
     # Create a new connection to PostgreSQL server.
     def connection
-      PG.connect(dbname: @dbname, host: @host, port: @port, user: @user, password: @password)
+      PG.connect(dbname: @dbname, host: @host, port: @port, user: @user, password: @password, **@opts)
     end
   end
 
@@ -54,21 +57,27 @@ module Pgtk::Wire
     # Constructor.
     #
     # @param [String] var The name of the environment variable with the connection URL
-    def initialize(var = 'DATABASE_URL')
+    # @param [Hash] opts Extra options forwarded to +PG.connect+ (e.g. +sslmode+,
+    #   +connect_timeout+, +keepalives+, +keepalives_idle+, +application_name+).
+    #   Explicit kwargs win over options carried in the URL query string on conflict.
+    def initialize(var = 'DATABASE_URL', **opts)
       raise(ArgumentError, "The name of the environment variable can't be nil") if var.nil?
       @value = ENV.fetch(var, nil)
       raise(ArgumentError, "The environment variable #{@value.inspect} is not set") if @value.nil?
+      @opts = opts
     end
 
     # Create a new connection to PostgreSQL server.
     def connection
       uri = URI(@value)
+      extras = uri.query ? URI.decode_www_form(uri.query).to_h.transform_keys(&:to_sym) : {}
       Pgtk::Wire::Direct.new(
         host: CGI.unescape(uri.host),
         port: uri.port || 5432,
         dbname: CGI.unescape(uri.path[1..]),
         user: CGI.unescape(uri.userinfo.split(':')[0]),
-        password: CGI.unescape(uri.userinfo.split(':')[1])
+        password: CGI.unescape(uri.userinfo.split(':')[1]),
+        **extras.merge(@opts)
       ).connection
     end
   end

--- a/test/test_wire.rb
+++ b/test/test_wire.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'cgi'
+require 'securerandom'
 require 'yaml'
 require_relative '../lib/pgtk/wire'
 require_relative 'test__helper'
@@ -43,6 +44,23 @@ class TestWire < Pgtk::Test
       wire = Pgtk::Wire::Env.new(v)
       e = assert_raises(PG::ConnectionBad, 'must attempt connection to default port') { wire.connection }
       assert_includes(e.message, 'port 5432', 'must default to port 5432 when port is omitted from URL')
+    end
+  end
+
+  def test_honors_url_query_options_in_env
+    fake_config do |f|
+      c = YAML.load_file(f)['pgsql']
+      v = 'DATABASE_URL_QUERY'
+      name = "pgtk_#{SecureRandom.hex(4)}"
+      ENV[v] = [
+        "postgres://#{CGI.escape(c['user'])}:#{CGI.escape(c['password'])}",
+        "@#{CGI.escape(c['host'])}:#{c['port']}/#{CGI.escape(c['dbname'])}",
+        "?application_name=#{name}"
+      ].join
+      actual = Pgtk::Wire::Env.new(v).connection.exec(
+        "SELECT current_setting('application_name')"
+      )[0]['current_setting']
+      assert_equal(name, actual, 'URL query options must be passed through to PG.connect')
     end
   end
 end

--- a/test/test_wire.rb
+++ b/test/test_wire.rb
@@ -63,4 +63,34 @@ class TestWire < Pgtk::Test
       assert_equal(name, actual, 'URL query options must be passed through to PG.connect')
     end
   end
+
+  def test_forwards_extra_opts_via_direct
+    fake_config do |f|
+      c = YAML.load_file(f)['pgsql']
+      name = "pgtk_#{SecureRandom.hex(4)}"
+      actual = Pgtk::Wire::Direct.new(
+        host: c['host'], port: c['port'], dbname: c['dbname'],
+        user: c['user'], password: c['password'],
+        application_name: name
+      ).connection.exec("SELECT current_setting('application_name')")[0]['current_setting']
+      assert_equal(name, actual, 'extra kwargs on Direct must reach PG.connect')
+    end
+  end
+
+  def test_explicit_kwargs_win_over_url_query
+    fake_config do |f|
+      c = YAML.load_file(f)['pgsql']
+      v = 'DATABASE_URL_PRECEDENCE'
+      ENV[v] = [
+        "postgres://#{CGI.escape(c['user'])}:#{CGI.escape(c['password'])}",
+        "@#{CGI.escape(c['host'])}:#{c['port']}/#{CGI.escape(c['dbname'])}",
+        '?application_name=from_url'
+      ].join
+      explicit = "pgtk_#{SecureRandom.hex(4)}"
+      actual = Pgtk::Wire::Env.new(v, application_name: explicit).connection.exec(
+        "SELECT current_setting('application_name')"
+      )[0]['current_setting']
+      assert_equal(explicit, actual, 'explicit kwargs must override URL query options on conflict')
+    end
+  end
 end


### PR DESCRIPTION
Closes #351.

Both `Pgtk::Wire::Direct` and `Pgtk::Wire::Env` now accept arbitrary keyword arguments and splat them into `PG.connect` after the explicit five, so callers can pass libpq settings like `sslmode`, `connect_timeout`, `keepalives`, `keepalives_idle`, `application_name`, and `target_session_attrs` without forking the wire. `Wire::Env` additionally parses the URL query string and merges it into the connect options, with explicit kwargs winning on conflict; the previous behavior silently discarded `uri.query`.