### PR TITLE
Fix #354: stop cache() from clearing :stale flag set by concurrent modify

### DIFF
--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -222,7 +222,8 @@ class Pgtk::Stash
     affected = (tables + tables.flat_map { |t| @cascades&.fetch(t, []) || [] }).uniq
     @entrance.with_write_lock do
       affected.each do |t|
-        @stash[:table_mod][t] = now
+        old = @stash[:table_mod][t]
+        @stash[:table_mod][t] = old && old > now ? old : now
         @stash[:tables][t]&.each do |q|
           @stash[:queries][q]&.each_key do |key|
             @stash[:queries][q][key][:stale] = now
@@ -237,18 +238,17 @@ class Pgtk::Stash
     key = params.join(SEPARATOR)
     ret = @stash.dig(:queries, pure, key, :ret)
     if ret.nil? || @stash.dig(:queries, pure, key, :stale)
-      mark = @stash.dig(:queries, pure, key, :stale)
       tables = pure.scan(/(?<=^|\s)(?:FROM|JOIN) ([a-z_]+)(?=\s|;|$)/).flatten
       tables.uniq!
       marks = tables.to_h { |t| [t, @stash[:table_mod][t]] }
       ret = @pool.exec(pure, params, result)
-      cache(pure, key, params, result, ret, mark, tables, marks) unless pure.include?(' NOW() ')
+      cache(pure, key, params, result, ret, tables, marks) unless pure.include?(' NOW() ')
     end
     bump(pure, key) if @stash.dig(:queries, pure, key)
     ret
   end
 
-  def cache(pure, key, params, result, ret, mark, tables, marks)
+  def cache(pure, key, params, result, ret, tables, marks)
     raise(ArgumentError, "No tables at #{pure.inspect}") if tables.empty?
     @entrance.with_write_lock do
       tables.each do |t|
@@ -257,10 +257,15 @@ class Pgtk::Stash
       end
       @stash[:queries][pure] ||= {}
       existing = @stash[:queries][pure][key]
-      stale = existing && existing[:stale]
       stillborn = tables.any? { |t| (cur = @stash[:table_mod][t]) && cur != marks[t] }
       entry = { ret:, params:, result:, used: Time.now }
-      entry[:stale] = stale == mark ? Time.now : stale if (stale && stale != mark) || stillborn
+      entry[:stale] =
+        if existing && existing[:stale]
+          existing[:stale]
+        elsif stillborn
+          Time.now
+        end
+      entry.delete(:stale) if entry[:stale].nil?
       @stash[:queries][pure][key] = entry
     end
   end

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -444,6 +444,29 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_list_query_converges_to_db_after_writer_churn
+    fake_pool(8) do |pool|
+      pool.exec('CREATE TABLE node (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)')
+      stash = Pgtk::Stash.new(pool, refill: 0.3, delay: 4, capping: 5, retirement: 5, retire: 600)
+      stash.start!
+      hammer(stash, 16, 2, 4, 10)
+      sleep(stash.instance_variable_get(:@refill) + stash.instance_variable_get(:@delay) + 2)
+      assert_empty(ghosts(stash, pool), 'list query keeps returning ghost ids whose rows no longer exist in DB')
+    end
+  end
+
+  def test_select_does_not_clear_stale_marker_on_cached_entry
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, refill: nil, capping: nil, retirement: nil)
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['A'])
+      stash.exec('SELECT title FROM book')
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['B'])
+      stash.exec('SELECT title FROM book')
+      entry = stash.instance_variable_get(:@stash)[:queries]['SELECT title FROM book'].values.first
+      refute_nil(entry[:stale], 'cache must not clear the stale marker; only replenish should clear it')
+    end
+  end
+
   def test_cascade_delete_invalidates_child_table_cache
     fake_pool do |pool|
       pool.exec('CREATE TABLE org (id INTEGER PRIMARY KEY)')
@@ -515,5 +538,11 @@ class TestStash < Pgtk::Test
       end
     end
     bugs
+  end
+
+  def ghosts(stash, pool)
+    truth = pool.exec('SELECT id FROM node').map { |r| Integer(r['id'], 10) }
+    listed = stash.exec('SELECT id FROM node ORDER BY id').map { |r| Integer(r['id'], 10) }
+    listed - truth
   end
 end


### PR DESCRIPTION
Closes #354.

Pgtk::Stash had a race where a SELECT could eat the `:stale` marker that a concurrent modify had just stamped on the same cached entry, leaving stale rows in the cache with no flag for `replenish()` to pick up — which is what caused the production Hub to keep serving ghost node ids for hours after a wave of cascade-driven DELETEs. The fix preserves `existing[:stale]` in `cache()` so only `replenish()` (which already gates on `h[:stale] == mark` under the lock) can clear it, and adds a `[old, now].max` guard in `modify()` so out-of-order lock acquisition between two concurrent modifies cannot regress `@stash[:table_mod][t]`. A failing test is added that asserts the invariant directly: a cached entry's `:stale` flag must survive a subsequent SELECT.