### PR TITLE
Address Copilot review on #354: stamp :stale monotonically alongside table_mod

### DIFF
--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -223,10 +223,11 @@ class Pgtk::Stash
     @entrance.with_write_lock do
       affected.each do |t|
         old = @stash[:table_mod][t]
-        @stash[:table_mod][t] = old && old > now ? old : now
+        stamp = old && old > now ? old : now
+        @stash[:table_mod][t] = stamp
         @stash[:tables][t]&.each do |q|
           @stash[:queries][q]&.each_key do |key|
-            @stash[:queries][q][key][:stale] = now
+            @stash[:queries][q][key][:stale] = stamp
           end
         end
       end


### PR DESCRIPTION
Follow-up to PR #355, which was merged before this commit landed. Copilot pointed out that the `[old, now].max` regression guard added in #355 protects `@stash[:table_mod][t]` but leaves the per-entry `:stale` marker still overwritten with the locally captured `now`, so two concurrent modifies acquiring the write lock out of order can rewind `:stale` even when `table_mod` stays monotonic — which would mislead `replenish()`'s `@delay` gating that uses `h[:stale]` as the timestamp. The change computes the monotonic stamp once and reuses it for both `table_mod` and the `:stale` assignment on every cached entry.