### PR TITLE
Widen Stash table-name regex to allow underscores and digits

### DIFF
--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -32,12 +32,16 @@ class Pgtk::Stash
   MODS = %w[INSERT DELETE UPDATE LOCK VACUUM TRANSACTION COMMIT ROLLBACK REINDEX TRUNCATE CREATE ALTER DROP SET].freeze
   MODS_RE = Regexp.new("(^|\\s)(#{MODS.join('|')})(\\s|$)")
 
+  IDENT = '[a-z_][a-z0-9_]*'
+
   ALTS = ['UPDATE', 'INSERT INTO', 'DELETE FROM', 'TRUNCATE', 'ALTER TABLE', 'DROP TABLE'].freeze
-  ALTS_RE = Regexp.new("(?<=^|\\s)(?:#{ALTS.join('|')})\\s([a-z]+)(?=[^a-z]|$)")
+  ALTS_RE = Regexp.new("(?<=^|\\s)(?:#{ALTS.join('|')})\\s(#{IDENT})(?=[^a-z0-9_]|$)")
+
+  READS_RE = Regexp.new("(?<=^|\\s)(?:FROM|JOIN)\\s(#{IDENT})(?=\\s|;|$)")
 
   SEPARATOR = ' --%*@#~($-- '
 
-  private_constant :MODS, :ALTS, :MODS_RE, :ALTS_RE, :SEPARATOR
+  private_constant :MODS, :ALTS, :IDENT, :MODS_RE, :ALTS_RE, :READS_RE, :SEPARATOR
 
   # Initialize a new Stash with query caching.
   #
@@ -239,7 +243,7 @@ class Pgtk::Stash
     key = params.join(SEPARATOR)
     ret = @stash.dig(:queries, pure, key, :ret)
     if ret.nil? || @stash.dig(:queries, pure, key, :stale)
-      tables = pure.scan(/(?<=^|\s)(?:FROM|JOIN) ([a-z_]+)(?=\s|;|$)/).flatten
+      tables = pure.scan(READS_RE).flatten
       tables.uniq!
       marks = tables.to_h { |t| [t, @stash[:table_mod][t]] }
       ret = @pool.exec(pure, params, result)

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -96,6 +96,41 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_invalidates_cache_for_table_whose_name_has_underscores
+    fake_pool do |pool|
+      pool.exec('CREATE TABLE user_settings (id INTEGER PRIMARY KEY, value TEXT NOT NULL)')
+      stash = Pgtk::Stash.new(pool)
+      query = 'SELECT value FROM user_settings WHERE id = $1'
+      first = stash.exec(query, [1])
+      stash.exec('INSERT INTO user_settings (id, value) VALUES ($1, $2)', [1, 'x'])
+      second = stash.exec(query, [1])
+      refute_same(first, second, 'cannot invalidate cache for a write into a table whose name has an underscore')
+    end
+  end
+
+  def test_invalidates_cache_for_table_whose_name_has_digits
+    fake_pool do |pool|
+      pool.exec('CREATE TABLE audit_log_2024 (id INTEGER PRIMARY KEY, msg TEXT NOT NULL)')
+      stash = Pgtk::Stash.new(pool)
+      query = 'SELECT msg FROM audit_log_2024 WHERE id = $1'
+      first = stash.exec(query, [1])
+      stash.exec('INSERT INTO audit_log_2024 (id, msg) VALUES ($1, $2)', [1, 'x'])
+      second = stash.exec(query, [1])
+      refute_same(first, second, 'cannot invalidate cache for a write into a table whose name has a digit')
+    end
+  end
+
+  def test_caches_select_from_table_whose_name_has_digits
+    fake_pool do |pool|
+      pool.exec('CREATE TABLE audit_log_2024 (id INTEGER PRIMARY KEY, msg TEXT NOT NULL)')
+      stash = Pgtk::Stash.new(pool)
+      query = 'SELECT msg FROM audit_log_2024 WHERE id = $1'
+      first = stash.exec(query, [1])
+      second = stash.exec(query, [1])
+      assert_same(first, second, 'cannot cache a SELECT from a table whose name has a digit')
+    end
+  end
+
   def test_caching_with_params
     fake_pool do |pool|
       stash = Pgtk::Stash.new(pool)


### PR DESCRIPTION
The two regexes in `Pgtk::Stash` that pull table names out of SQL only
recognised `[a-z]+` on the write side and `[a-z_]+` on the read side.
Both are now widened to a common PostgreSQL identifier pattern,
`[a-z_][a-z0-9_]*`, and extracted into a shared `IDENT` constant so the
two sides cannot drift again.

Without this fix, an `INSERT INTO user_settings (...)` was reported as
touching a phantom table named `user`, and `SELECT * FROM audit_log_2024`
crashed with `No tables at ...`. Cached SELECTs against any table whose
name contained an underscore or a digit were therefore never marked
stale when the table was written, so callers kept reading stale data.
Three new tests cover the underscore case, the digit case on writes,
and the digit case on reads.

Quoted identifiers (`\"My Table\"`) and schema prefixes (`public.t`) are
still out of scope and would be a reasonable follow-up.

Closes #364