### PR TITLE
Replace Time.now stamp with per-table integer counter in Stash#modify

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
     prism (1.9.0)
-    qbash (0.8.3)
+    qbash (0.8.4)
       backtrace (> 0)
       elapsed (> 0)
       loog (> 0)

--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -231,12 +231,10 @@ class Pgtk::Stash
         @entrance.with_write_lock do
           affected.each do |t|
             @stash[:table_inflight][t] -= 1
-            old = @stash[:table_mod][t]
-            stamp = old && old > now ? old : now
-            @stash[:table_mod][t] = stamp
+            @stash[:table_mod][t] = (@stash[:table_mod][t] || 0) + 1
             @stash[:tables][t]&.each do |q|
               @stash[:queries][q]&.each_key do |key|
-                @stash[:queries][q][key][:stale] = stamp
+                @stash[:queries][q][key][:stale] = now
               end
             end
           end

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -511,9 +511,7 @@ class TestStash < Pgtk::Test
             next if triggered
             next unless q.start_with?('SELECT title FROM book')
             triggered = true
-            Time.stub(:now, frozen) do
-              stash.exec('INSERT INTO book (title) VALUES ($1)', ['B'])
-            end
+            stash.exec('INSERT INTO book (title) VALUES ($1)', ['B'])
           end
         ),
         refill: nil, capping: nil, retirement: nil

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -499,6 +499,39 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_two_writes_same_tick_marks_cache_stillborn
+    fake_pool do |real_pool|
+      triggered = false
+      stash = nil
+      frozen = Time.now
+      stash = Pgtk::Stash.new(
+        HookedPool.new(
+          real_pool,
+          lambda do |q|
+            next if triggered
+            next unless q.start_with?('SELECT title FROM book')
+            triggered = true
+            Time.stub(:now, frozen) do
+              stash.exec('INSERT INTO book (title) VALUES ($1)', ['B'])
+            end
+          end
+        ),
+        refill: nil, capping: nil, retirement: nil
+      )
+      Time.stub(:now, frozen) do
+        stash.exec('INSERT INTO book (title) VALUES ($1)', ['A'])
+      end
+      Time.stub(:now, frozen) do
+        stash.exec('SELECT title FROM book')
+      end
+      assert_includes(
+        stash.exec('SELECT title FROM book').map { |r| r['title'] },
+        'B',
+        'must detect stillborn cache when two writes share the same clock tick'
+      )
+    end
+  end
+
   def test_replenish_survives_eviction
     fake_pool do |pool|
       stash = Pgtk::Stash.new(pool, refill: nil, capping: nil, retirement: nil, delay: 0)


### PR DESCRIPTION
Fixes #368.

## Problem

When two writes to the same table happen within the same clock tick, `Time.now` returns identical values. The second write leaves `@stash[:table_mod][t]` unchanged, so the `stillborn` check in `cache` (`cur != marks[t]`) sees equal values and fails to detect that the table was modified between when the SELECT captured `marks` and when it tried to cache the result. A `SELECT` that executes its DB query in this window caches a stale snapshot without a `:stale` marker.

## Fix

Replace the wall-clock stamp in `table_mod[t]` with a per-table integer counter, incremented (under the write lock) on every modify. Two writes to the same table always produce distinct version values regardless of clock resolution or NTP adjustments.

The `:stale` marker stored on query cache entries is kept as `Time.now` — the `replenish` path uses it for delay-based scheduling (`h[:stale] > Time.now - @delay`), so that logic is unaffected.

## Test

`test_two_writes_same_tick_marks_cache_stillborn` — uses `HookedPool` to inject a second write during the SELECT/cache window while `Time.now` is frozen, then asserts the subsequent SELECT returns fresh data.