### PR TITLE
#376: fix Spy#exec duration always being 0

### DIFF
--- a/lib/pgtk/spy.rb
+++ b/lib/pgtk/spy.rb
@@ -82,8 +82,10 @@ class Pgtk::Spy
   # @param [String] sql The SQL query with params inside (possibly)
   # @return [Array] Result rows
   def exec(sql, *)
-    @block&.call(sql.is_a?(Array) ? sql.join(' ') : sql, Time.now - Time.now)
-    @pool.exec(sql, *)
+    start = Time.now
+    @pool.exec(sql, *).tap do
+      @block&.call(sql.is_a?(Array) ? sql.join(' ') : sql, Time.now - start)
+    end
   end
 
   # Run a transaction with spying on each SQL query.

--- a/test/test_spy.rb
+++ b/test/test_spy.rb
@@ -45,6 +45,15 @@ class TestSpy < Pgtk::Test
     end
   end
 
+  def test_duration
+    durations = []
+    fake_pool do |pool|
+      Pgtk::Spy.new(pool) { |_sql, d| durations << d }.exec('SELECT 1')
+    end
+    refute_empty(durations, 'callback must be called')
+    assert_operator(durations.first, :>, 0, "duration must be greater than 0, got: #{durations.first}")
+  end
+
   def test_start
     fake_pool do |pool|
       stash = Pgtk::Spy.new(pool)


### PR DESCRIPTION
Fixes #376

## Problem

`Pgtk::Spy#exec` computes duration as `Time.now - Time.now`, which is always ~0.0, making the `duration` parameter in the callback useless.

## Solution

Wrap the actual `@pool.exec` call with proper timing using `Time.now` captured before execution.

## Changes

- `lib/pgtk/spy.rb` — fix timing computation in `#exec`
- `test/test_spy.rb` — add `test_duration` to verify duration > 0

## Verification

- [ ] `bundle exec rubocop` — 0 offenses
- [ ] `bundle exec rake test` — passes