### PR TITLE
#384: protect Pool#start! with Mutex for thread safety

### DIFF
--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -73,6 +73,7 @@ class Pgtk::Pool
     @idle = idle
     @log = log
     @pool = IterableQueue.new(max, timeout)
+    @init_lock = Mutex.new
     @started = false
   end
 
@@ -103,20 +104,22 @@ class Pgtk::Pool
   # open at the same time. For example, Heroku free PostgreSQL database
   # allows only one connection open.
   def start!
-    return if @started
-    @max.times do
-      @pool.push(@wire.connection)
+    @init_lock.synchronize do
+      return if @started
+      @max.times do
+        @pool.push(@wire.connection)
+      end
+      (2 * @max).times do
+        connect { |c| c.exec('SELECT 1') }
+      rescue StandardError => e
+        @log.warn("Pool warm-up query failed, slot will be retried: #{e.message.strip}")
+      end
+      @max.times do
+        connect { |c| c.exec('SELECT 1') }
+      end
+      @started = true
+      @log.debug("PostgreSQL pool started with #{@max} connections")
     end
-    (2 * @max).times do
-      connect { |c| c.exec('SELECT 1') }
-    rescue StandardError => e
-      @log.warn("Pool warm-up query failed, slot will be retried: #{e.message.strip}")
-    end
-    @max.times do
-      connect { |c| c.exec('SELECT 1') }
-    end
-    @started = true
-    @log.debug("PostgreSQL pool started with #{@max} connections")
   end
 
   # Make a query and return the result as an array of hashes. For example,

--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -73,7 +73,7 @@ class Pgtk::Pool
     @idle = idle
     @log = log
     @pool = IterableQueue.new(max, timeout)
-    @init_lock = Mutex.new
+    @lock = Mutex.new
     @started = false
   end
 
@@ -104,7 +104,7 @@ class Pgtk::Pool
   # open at the same time. For example, Heroku free PostgreSQL database
   # allows only one connection open.
   def start!
-    @init_lock.synchronize do
+    @lock.synchronize do
       return if @started
       @max.times do
         @pool.push(@wire.connection)

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -305,6 +305,15 @@ class TestPool < Pgtk::Test
     end
   end
 
+  def test_concurrent_start
+    fake_config do |f|
+      pool = Pgtk::Pool.new(Pgtk::Wire::Yaml.new(f), max: 4)
+      Array.new(3) { Thread.new { pool.start! } }.each(&:join)
+      pool.start!
+      assert_equal('42', pool.exec('SELECT 42 AS n')[0]['n'], 'pool must work after concurrent start')
+    end
+  end
+
   def test_no_double_login_on_renew_failure
     fake_pool(1) do |pool|
       pool.exec('SELECT 1')


### PR DESCRIPTION
Fixes #384

## Problem

`Pool#start!` has no synchronization on the `@started` flag. Concurrent calls from multiple threads can both see `@started == false` and both proceed to initialize connections. Additionally, partial pool state is exposed during warm-up before `@started` is set to true.

## Solution

Guard the entire startup sequence with `@init_lock` (a new `Mutex`). This ensures:
1. Only one thread initializes the pool
2. Subsequent callers immediately see `@started == true`
3. The pool is fully warmed up before being exposed to callers

## Changes

- `lib/pgtk/pool.rb` — add `@init_lock` in constructor, wrap `start!` body in synchronize
- `test/test_pool.rb` — add `test_concurrent_start`

## Verification

- [ ] `bundle exec rubocop` — 0 offenses
- [ ] `bundle exec rake` — passes