### PR TITLE
#386: add fallback timeout for excluded Impatient queries

### DIFF
--- a/lib/pgtk/impatient.rb
+++ b/lib/pgtk/impatient.rb
@@ -63,10 +63,12 @@ class Pgtk::Impatient
   # @param [Pgtk::Pool] pool The pool to decorate
   # @param [Integer] timeout Timeout in seconds for each SQL query
   # @param [Array<Regex>] off List of regex to exclude queries from checking
-  def initialize(pool, timeout, *off)
+  # @param [Integer] default Fallback timeout in seconds for excluded queries (0 = no timeout)
+  def initialize(pool, timeout, *off, default: 300)
     @pool = pool
     @timeout = timeout
     @off = off
+    @default = default
   end
 
   # Start a new connection pool with the given arguments.
@@ -86,7 +88,7 @@ class Pgtk::Impatient
     [
       @pool.dump,
       '',
-      "Pgtk::Impatient (timeout=#{@timeout}s):",
+      "Pgtk::Impatient (timeout=#{@timeout}s, default=#{@default}s):",
       @off.map { |re| "  #{re}" }
     ].join("\n")
   end
@@ -106,7 +108,13 @@ class Pgtk::Impatient
   # @raise [TooSlow] If the query takes too long
   def exec(query, *args)
     sql = query.is_a?(Array) ? query.join(' ') : query
-    return @pool.exec(sql, *args) if @off.any? { |re| re.match?(sql) }
+    if @off.any? { |re| re.match?(sql) }
+      ms = Integer(@default * 1000)
+      return @pool.transaction do |t|
+        t.exec("SET LOCAL statement_timeout = #{ms}") unless ms.zero?
+        t.exec(sql, *args)
+      end
+    end
     start = Time.now
     ms = [Integer(@timeout * 1000), 1].max
     begin

--- a/test/test_impatient.rb
+++ b/test/test_impatient.rb
@@ -107,13 +107,43 @@ class TestImpatient < Pgtk::Test
     end
   end
 
-  def test_skips_timeout_for_excluded_queries
+  def test_excluded_still_timed_out
     fake_pool do |pool|
       captured = []
       Pgtk::Impatient.new(Pgtk::Spy.new(pool) { |sql, _| captured << sql }, 1.5, /^SELECT 1/).exec('SELECT 1')
+      assert(
+        captured.any? { |s| s.match?(/SET LOCAL statement_timeout\s*=\s*300000\b/) },
+        "must set default 300s statement_timeout for excluded queries, got: #{captured.inspect}"
+      )
+    end
+  end
+
+  def test_excluded_custom_default
+    fake_pool do |pool|
+      captured = []
+      Pgtk::Impatient.new(
+        Pgtk::Spy.new(pool) do |sql, _|
+          captured << sql
+        end, 1.5, /^SELECT 1/, default: 10
+      ).exec('SELECT 1')
+      assert(
+        captured.any? { |s| s.match?(/SET LOCAL statement_timeout\s*=\s*10000\b/) },
+        "must set custom default timeout, got: #{captured.inspect}"
+      )
+    end
+  end
+
+  def test_excluded_zero_default
+    fake_pool do |pool|
+      captured = []
+      Pgtk::Impatient.new(
+        Pgtk::Spy.new(pool) do |sql, _|
+          captured << sql
+        end, 1.5, /^SELECT 1/, default: 0
+      ).exec('SELECT 1')
       refute(
         captured.any? { |s| s.include?('SET LOCAL statement_timeout') },
-        "must not set statement_timeout for excluded queries, got: #{captured.inspect}"
+        "must not set statement_timeout when default is 0, got: #{captured.inspect}"
       )
     end
   end


### PR DESCRIPTION
Fixes #386

## Problem

When a query matches an exclusion regex, `Impatient#exec` delegates directly to `@pool.exec` without any timeout at all. The bare pool has no timeout mechanism — it relies on the PG client's `statement_timeout` (unlimited by default). A hanging excluded query blocks its pool slot indefinitely.

## Solution

Add a `default:` keyword parameter (300s default) for excluded queries. They are now wrapped in a transaction with `SET LOCAL statement_timeout` set to the fallback value. Setting `default: 0` disables timeout for excluded queries (PG `statement_timeout = 0` means no timeout).

## Changes

- `lib/pgtk/impatient.rb` — add `@default` ivar, wrap excluded queries in transaction with fallback timeout, update `dump`
- `test/test_impatient.rb` — rename and update existing test, add `test_excluded_custom_default`, `test_excluded_zero_default`

## Verification

- [x] `bundle exec rubocop` — 0 offenses
