### PR TITLE
#392: forward extra PG connection options from Wire::Yaml

### DIFF
--- a/lib/pgtk/wire/yaml.rb
+++ b/lib/pgtk/wire/yaml.rb
@@ -19,11 +19,14 @@ class Pgtk::Wire::Yaml
   #
   # @param [String] file Path to the YAML configuration file
   # @param [String] node The root node name in the YAML file containing PostgreSQL configuration
-  def initialize(file, node = 'pgsql')
+  # @param [Hash] opts Extra options forwarded to +PG.connect+ (e.g. +sslmode+,
+  #   +connect_timeout+, +keepalives+). These override values from the YAML file.
+  def initialize(file, node = 'pgsql', **opts)
     raise(ArgumentError, "The name of the file can't be nil") if file.nil?
     @file = file
     raise(ArgumentError, "The name of the node in the YAML file can't be nil") if node.nil?
     @node = node
+    @opts = opts
   end
 
   # Create a new connection to PostgreSQL server.
@@ -36,7 +39,9 @@ class Pgtk::Wire::Yaml
       port: cfg[@node]['port'],
       dbname: cfg[@node]['dbname'],
       user: cfg[@node]['user'],
-      password: cfg[@node]['password']
+      password: cfg[@node]['password'],
+      **cfg[@node].except(*%w[host port dbname user password url]).transform_keys(&:to_sym),
+      **@opts
     ).connection
   end
 end

--- a/test/test_wire.rb
+++ b/test/test_wire.rb
@@ -81,6 +81,21 @@ class TestWire < Pgtk::Test
     end
   end
 
+  def test_yaml_forwards_extra_opts
+    fake_config do |f|
+      c = YAML.load_file(f)
+      c['pgsql']['application_name'] = "pgtk_#{SecureRandom.hex(4)}"
+      File.write(f, YAML.dump(c))
+      assert_equal(
+        c['pgsql']['application_name'],
+        Pgtk::Wire::Yaml.new(f).connection.exec(
+          "SELECT current_setting('application_name')"
+        )[0]['current_setting'],
+        'extra YAML keys must reach PG.connect'
+      )
+    end
+  end
+
   def test_explicit_kwargs_win_over_url_query
     fake_config do |f|
       c = YAML.load_file(f)['pgsql']


### PR DESCRIPTION
Fixes #392

## Problem

`Wire::Direct` and `Wire::Env` both support extra `**opts` forwarded to `PG.connect` (e.g., `sslmode`, `connect_timeout`). `Wire::Yaml` does not — it only passes the 5 standard keys from YAML config, making PG connection options inaccessible for YAML-based configs.

## Solution

1. Accept `**opts` in the constructor, stored as `@opts`
2. In `connection`, forward extra YAML keys (anything beyond `host`, `port`, `dbname`, `user`, `password`, `url`) to `Wire::Direct`
3. Constructor kwargs override YAML file values

## Changes

- `lib/pgtk/wire/yaml.rb` — add `**opts`, merge YAML extras + kwargs
- `test/test_wire.rb` — add `test_yaml_forwards_extra_opts`

## Verification

- [x] `bundle exec rubocop` — 0 offenses
