### PR TITLE
#394: use PG connection parameter instead of SQL for server version

### DIFF
--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -80,7 +80,12 @@ class Pgtk::Pool
   #
   # @return [String] Version of PostgreSQL server
   def version
-    @version ||= exec('SHOW server_version')[0]['server_version'].split[0]
+    @version ||=
+      begin
+        conn = @pool.pop
+        @pool.push(conn)
+        conn.parameter_status('server_version').split[0]
+      end
   end
 
   # Get as much details about it as possible.


### PR DESCRIPTION
Fixes #394

## Problem

`Pool#version` uses `exec('SHOW server_version')` which consumes a pool slot and goes through the full exec pipeline. PostgreSQL exposes the server version via `PG::Connection#parameter_status('server_version')` at zero cost.

## Solution

Pop a connection, read `parameter_status('server_version')`, push it back. Memoize via `@version`.

## Changes

- `lib/pgtk/pool.rb` — replace `exec('SHOW server_version')` with `parameter_status`

## Verification

- [x] `bundle exec rubocop` — 0 offenses
