### PR TITLE
#398: move SPDX header before require statements in pool.rb and spy.rb

### DIFF
--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'loog'
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
 require 'ellipsized'
+require 'loog'
 require 'pg'
 require 'tago'
 require_relative '../pgtk'

--- a/lib/pgtk/spy.rb
+++ b/lib/pgtk/spy.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'loog'
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'loog'
 require 'pg'
 require_relative '../pgtk'
 require_relative 'wire'


### PR DESCRIPTION
Fixes #398

## Problem

Two files have `require` statements before the SPDX header:
- `lib/pgtk/pool.rb` — `require 'loog'` before SPDX
- `lib/pgtk/spy.rb` — `require 'loog'` before SPDX

All other 20+ `.rb` files in the project have SPDX headers right after `# frozen_string_literal: true`, before any requires.

## Fix

Move `require 'loog'` to after the SPDX header in both files. Trivial formatting fix, no behavioral change.

## Verification

- [x] `bundle exec rubocop` — 0 offenses
