### PR TITLE
#402: remove unused backtrace gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     pgtk (0.0.0)
-      backtrace (~> 0.4)
       concurrent-ruby (~> 1.3)
       donce (~> 0.0)
       ellipsized (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     pgtk (0.0.0)
+      cgi (~> 0.0)
       concurrent-ruby (~> 1.3)
       donce (~> 0.0)
       ellipsized (~> 0.3)
@@ -21,6 +22,7 @@ GEM
     ast (2.4.3)
     backtrace (0.4.1)
     builder (3.3.0)
+    cgi (0.5.1)
     concurrent-ruby (1.3.6)
     differ (0.1.2)
     docile (1.4.1)

--- a/lib/pgtk/pgsql_task.rb
+++ b/lib/pgtk/pgsql_task.rb
@@ -129,6 +129,10 @@ class Pgtk::PgsqlTask < Rake::TaskLib
       "-e POSTGRES_DB=#{Shellwords.escape(@dbname)}",
       '--detach',
       '--rm',
+      '--health-cmd', 'pg_isready',
+      '--health-interval', '1s',
+      '--health-timeout', '2s',
+      '--health-retries', '10',
       'postgres:18.1',
       @config.map { |k, v| "-c #{Shellwords.escape("#{k}=#{v}")}" },
       stdout:
@@ -147,6 +151,15 @@ class Pgtk::PgsqlTask < Rake::TaskLib
       WaitUtil.wait_for_service('PG in Docker', 'localhost', port, timeout_sec: 10, delay_sec: 0.1)
     rescue WaitUtil::TimeoutError => e
       raise(IOError, "Failed to start PostgreSQL Docker container #{container.inspect}: #{e.message}")
+    end
+    (30 * 2).times do
+      status = qbash(
+        "docker inspect --format='{{.State.Health.Status}}' #{Shellwords.escape(container)}",
+        accept: nil, both: true
+      )[0]&.strip
+      break if status == 'healthy'
+      raise(IOError, "PostgreSQL container #{container.inspect} is #{status}") if status == 'unhealthy'
+      sleep(0.5)
     end
     container
   end

--- a/pgtk.gemspec
+++ b/pgtk.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE.txt']
+  s.add_dependency('cgi', '~>0.0')
   s.add_dependency('concurrent-ruby', '~>1.3')
   s.add_dependency('donce', '~>0.0')
   s.add_dependency('ellipsized', '~>0.3')

--- a/pgtk.gemspec
+++ b/pgtk.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = ['README.md', 'LICENSE.txt']
-  s.add_dependency('backtrace', '~>0.4')
   s.add_dependency('concurrent-ruby', '~>1.3')
   s.add_dependency('donce', '~>0.0')
   s.add_dependency('ellipsized', '~>0.3')


### PR DESCRIPTION
Fixes #402

## Problem

The `backtrace` gem is listed as a runtime dependency but never `require`d anywhere in the source code. It's installed for every user of pgtk but provides no value.

Additionally, Docker CI was failing because `WaitUtil.wait_for_service` only checks TCP port availability (opens immediately in Docker-in-Docker), but PostgreSQL inside the container isn't ready yet — Liquibase/Maven then fails with `EOFException`.

Also, Ruby 4.0 removed the `cgi` library from stdlib; it must be declared as an explicit gem dependency.

## Fix

1. Remove unused `s.add_dependency('backtrace', '~>0.4')` from `pgtk.gemspec`
2. Add `--health-cmd pg_isready` to `docker run` in `pgsql_task.rb` and wait for container `healthy` status before returning
3. Add `s.add_dependency('cgi', '~>0.0')` for Ruby 4.0 compatibility

## Verification

- [x] `bundle exec rubocop` — 0 offenses
- [x] Docker CI — green (was failing with PostgreSQL startup race)
- [x] Rake CI — green
