### PR TITLE
#404: fix Wire::Env error message and add .yardopts

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+--markup markdown
+--hide-void-return
+--no-private

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
 --markup markdown
 --hide-void-return
 --no-private

--- a/lib/pgtk/wire/env.rb
+++ b/lib/pgtk/wire/env.rb
@@ -29,7 +29,7 @@ class Pgtk::Wire::Env
   def initialize(var = 'DATABASE_URL', **opts)
     raise(ArgumentError, "The name of the environment variable can't be nil") if var.nil?
     @value = ENV.fetch(var, nil)
-    raise(ArgumentError, "The environment variable #{@value.inspect} is not set") if @value.nil?
+    raise(ArgumentError, "The environment variable #{var.inspect} is not set") if @value.nil?
     @opts = opts
   end
 


### PR DESCRIPTION
Fixes #404

## Changes

1. **Wire::Env error message** — use `var.inspect` instead of `@value.inspect` so the error shows the env variable name (e.g., `DATABASE_URL`) instead of `nil` when the variable is not set
2. **`.yardopts`** — add basic YARD config (`--markup markdown`, `--hide-void-return`, `--no-private`) to prevent future warnings from default settings

## Verification

- [x] `bundle exec rubocop` — 0 offenses
