### PR TITLE
Keep Stash#bump off the exclusive write lock (#414)

### DIFF
--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -146,7 +146,7 @@ class Pgtk::Stash
       {
         q: q.dup,
         c: kk.values.count,
-        p: kk.values.sum { |vv| vv[:popularity] },
+        p: kk.values.sum { |vv| vv[:popularity]&.value || 0 },
         s: kk.values.count { |vv| vv[:stale] },
         u: kk.values.map { |vv| vv[:used] }.max || Time.now
       }
@@ -280,23 +280,32 @@ class Pgtk::Stash
           Time.now
         end
       entry.delete(:stale) if entry[:stale].nil?
+      entry[:popularity] = (existing && existing[:popularity]) || Concurrent::AtomicFixnum.new
       @stash[:queries][pure][params] = entry
     end
   end
 
+  # Bump popularity and last-used time of a cached entry.
+  #
+  # This runs without the exclusive write lock: popularity is a
+  # +Concurrent::AtomicFixnum+ and +used+ is a plain assignment of an
+  # immutable value, neither of which mutates the structure of the
+  # +@stash[:queries]+ tree. Keeping it off the writer lock means a
+  # read-only workload never serializes through the writer (see #414).
+  #
+  # @return [void]
   def bump(pure, params)
-    @entrance.with_write_lock do
-      @stash[:queries][pure][params][:popularity] ||= 0
-      @stash[:queries][pure][params][:popularity] += 1
-      @stash[:queries][pure][params][:used] = Time.now
-    end
+    entry = @stash.dig(:queries, pure, params)
+    return unless entry
+    (entry[:popularity] ||= Concurrent::AtomicFixnum.new).increment
+    entry[:used] = Time.now
   end
 
   # Calculate total number of cached query results.
   #
   # @return [Integer] Total count of cached query results
   def cached
-    @entrance.with_write_lock do
+    @entrance.with_read_lock do
       @stash[:queries].values.sum { |kk| kk.values.size }
     end
   end
@@ -386,7 +395,7 @@ class Pgtk::Stash
     qq =
       @entrance.with_write_lock do
         @stash[:queries]
-          .map { |k, v| [k, v.values.sum { |vv| vv[:popularity] }, v.values.any? { |vv| vv[:stale] }] }
+          .map { |k, v| [k, v.values.sum { |vv| vv[:popularity]&.value || 0 }, v.values.any? { |vv| vv[:stale] }] }
       end
     qq.select { _1[2] }.sort_by { -_1[1] }.map { _1[0] }
   end

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'threads'
+require 'timeout'
 require_relative '../lib/pgtk/pool'
 require_relative '../lib/pgtk/stash'
 require_relative 'test__helper'
@@ -604,6 +605,54 @@ class TestStash < Pgtk::Test
       hammer(stash, 16, 2, 4, 10)
       sleep(stash.instance_variable_get(:@refill) + stash.instance_variable_get(:@delay) + 2)
       assert_empty(ghosts(stash, pool), 'list query keeps returning ghost ids whose rows no longer exist in DB')
+    end
+  end
+
+  def test_cache_hit_does_not_block_on_reader
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, refill: nil, capping: nil, retirement: nil)
+      stash.start!
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Elegant Objects'])
+      query = 'SELECT id, title FROM book WHERE id = $1'
+      stash.exec(query, [1])
+      Thread.new { stash.instance_variable_get(:@entrance).with_read_lock { sleep(3) } }
+      sleep(0.5)
+      assert_equal(
+        'Elegant Objects',
+        Timeout.timeout(2) { stash.exec(query, [1]) }.first['title'],
+        'a cache hit must not serialize through the writer while a reader holds the lock'
+      )
+    end
+  end
+
+  def test_cache_hit_bumps_popularity
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, refill: nil, capping: nil, retirement: nil)
+      stash.start!
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Elegant Objects'])
+      query = 'SELECT id, title FROM book WHERE id = $1'
+      5.times { stash.exec(query, [1]) }
+      assert_equal(
+        5,
+        stash.instance_variable_get(:@stash)[:queries][query].values.first[:popularity].value,
+        'every cache hit must bump popularity'
+      )
+    end
+  end
+
+  def test_cached_count_does_not_block_on_reader
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, refill: nil, capping: nil, retirement: nil)
+      stash.start!
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Elegant Objects'])
+      stash.exec('SELECT id, title FROM book WHERE id = $1', [1])
+      Thread.new { stash.instance_variable_get(:@entrance).with_read_lock { sleep(3) } }
+      sleep(0.5)
+      assert_includes(
+        Timeout.timeout(2) { stash.dump },
+        'queries cached',
+        'counting cached entries must take the read lock, not the writer'
+      )
     end
   end
 


### PR DESCRIPTION
Fixes #414.

## Problem

Every cache hit serialized on the exclusive write lock. `Stash#select` calls `bump` on a hit (`lib/pgtk/stash.rb:261`), and `bump` acquired `@entrance.with_write_lock` just to bump popularity and `used`. `cached` did the same for a pure count. So a read-only workload ran fully serialized through the writer lock instead of the reader lock.

Because `ReentrantReadWriteLock` blocks new readers while a writer is queued, one slow holder stalls every thread. The background scans (`capper!`, `retiree!`, `ranked`) hold the write lock while iterating up to `cap` entries, so a request's `bump` colliding with a scan parks in `acquire_write_lock` — observed in production as a `Rack::Timeout`.

## Fix

- Store popularity as a `Concurrent::AtomicFixnum`, initialized in `cache` (carried over across re-caches) and incremented in `bump`.
- `bump` no longer takes any lock: it fetches the entry once (nil-guarded against concurrent eviction), increments the atomic counter, and assigns `used` — neither mutates the structure of the `@stash[:queries]` tree.
- `cached` counts under `with_read_lock` instead of `with_write_lock`.
- Readers of popularity (`queries`, `ranked`) now read `&.value`.

This is the read-side analog of the write-side `AtomicFixnum` approach in #396.

## Tests

Added three regression tests to `test/test_stash.rb`, all of which fail against the unfixed code:

- `test_cache_hit_does_not_block_on_reader` — a cache hit completes within a timeout while another thread holds the read lock (would block on the writer before the fix).
- `test_cached_count_does_not_block_on_reader` — `dump`/`cached` does not serialize through the writer.
- `test_cache_hit_bumps_popularity` — popularity still accumulates across hits.

Full `test/test_stash.rb` suite: 39 tests, 136 assertions, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USv2ZyeQEYuusi9r7PeMYa)_