### PR TITLE
#416: don't wrap off-list Impatient queries in a transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ You can exclude specific queries from timeout enforcement using regex patterns:
 impatient = Pgtk::Impatient.new(pool, 2, /^SELECT/, /^VACUUM/)
 ```
 
+Excluded queries are never wrapped in a transaction, because statements such as
+`VACUUM`, `REINDEX`, or `CREATE INDEX CONCURRENTLY` cannot run inside a
+transaction block. Instead, a longer fallback timeout (300 seconds by default,
+configurable via the `default:` argument) is applied at the session level with
+`SET statement_timeout` before the query runs, and reset afterwards. Pass
+`default: 0` to run excluded queries with no timeout at all:
+
+```ruby
+# Give excluded queries a 60-second fallback timeout
+impatient = Pgtk::Impatient.new(pool, 2, /^VACUUM/, default: 60)
+```
+
 The timeout is enforced on the server side: each query is wrapped in a tiny
 transaction that issues `SET LOCAL statement_timeout`, and PostgreSQL itself
 terminates the query at the deadline. This guarantees the server-side

--- a/lib/pgtk/impatient.rb
+++ b/lib/pgtk/impatient.rb
@@ -20,6 +20,14 @@ require_relative '../pgtk'
 # transaction-pool PgBouncer that does not forward client disconnects to in-flight
 # server queries). On timeout, +TooSlow+ is raised.
 #
+# Queries that match one of the +off+ regular expressions are excluded from
+# this checking. They are never wrapped in a transaction, because some
+# statements (such as +VACUUM+, +REINDEX+, or +CREATE INDEX CONCURRENTLY+)
+# cannot run inside a transaction block. Instead, a session-level
+# +SET statement_timeout+ is applied on the same connection before the query
+# runs (and reset afterwards), using the +default+ fallback timeout. Pass
+# +default: 0+ to run excluded queries with no timeout at all.
+#
 # Basic usage:
 #
 #   # Create and configure a regular pool
@@ -102,6 +110,13 @@ class Pgtk::Impatient
   # behind a transaction-pool PgBouncer). When the deadline fires, the
   # underlying +PG::QueryCanceled+ is translated to +TooSlow+.
   #
+  # Queries matching one of the +off+ regular expressions bypass this
+  # transaction. They run on a single connection without a transaction block,
+  # guarded by a session-level +SET statement_timeout+ (the +default+ fallback,
+  # reset afterwards) or by no timeout at all when +default+ is zero. This keeps
+  # statements that cannot run inside a transaction, such as +VACUUM+ or
+  # +REINDEX+, working as expected.
+  #
   # @param [String, Array] query The SQL query with params inside (possibly)
   # @param [Array] args List of arguments
   # @return [Array] Result rows
@@ -110,9 +125,10 @@ class Pgtk::Impatient
     sql = query.is_a?(Array) ? query.join(' ') : query
     if @off.any? { |re| re.match?(sql) }
       ms = Integer(@default * 1000)
-      return @pool.transaction do |t|
-        t.exec("SET LOCAL statement_timeout = #{ms}") unless ms.zero?
-        t.exec(sql, *args)
+      return @pool.exec(sql, *args) if ms.zero?
+      return @pool.session do |t|
+        t.exec("SET statement_timeout = #{ms}")
+        t.exec(sql, *args).tap { t.exec('RESET statement_timeout') }
       end
     end
     start = Time.now

--- a/lib/pgtk/pool.rb
+++ b/lib/pgtk/pool.rb
@@ -214,6 +214,29 @@ class Pgtk::Pool
     end
   end
 
+  # Grab a single connection from the pool and yield an executor bound to it,
+  # WITHOUT starting a transaction. Unlike +transaction+, no +START TRANSACTION+
+  # is issued, which makes this suitable for statements that PostgreSQL refuses
+  # to run inside a transaction block, such as +VACUUM+, +REINDEX+, or
+  # +CREATE INDEX CONCURRENTLY+. All statements executed through the yielded
+  # object run on the same connection, so a session-level setting (for example
+  # +SET statement_timeout+) made earlier in the block stays in effect for the
+  # statements that follow:
+  #
+  #  pgsql.session do |s|
+  #    s.exec('SET statement_timeout = 5000')
+  #    s.exec('VACUUM book')
+  #    s.exec('RESET statement_timeout')
+  #  end
+  #
+  # @yield [Object] Yields an executor that responds to +exec+
+  # @return [Object] Result of the block
+  def session
+    connect do |c|
+      yield(Txn.new(c, @log))
+    end
+  end
+
   private
 
   def connect

--- a/lib/pgtk/spy.rb
+++ b/lib/pgtk/spy.rb
@@ -97,4 +97,15 @@ class Pgtk::Spy
       yield(Pgtk::Spy.new(t, &@block))
     end
   end
+
+  # Run statements on a single connection (no transaction) with spying on
+  # each SQL query.
+  #
+  # @yield [Pgtk::Spy] Yields a spy bound to one connection
+  # @return [Object] Result of the block
+  def session
+    @pool.session do |t|
+      yield(Pgtk::Spy.new(t, &@block))
+    end
+  end
 end

--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -149,6 +149,16 @@ class Pgtk::Stash
     end
   end
 
+  # Run statements on a single connection, without a transaction.
+  #
+  # @yield [Pgtk::Stash] A stash bound to the connection
+  # @return [Object] The result of the block
+  def session
+    @pool.session do |t|
+      yield(Pgtk::Stash.new(t, stash: @stash, loog: @loog, entrance: @entrance))
+    end
+  end
+
   private
 
   def queries

--- a/test/test_impatient.rb
+++ b/test/test_impatient.rb
@@ -112,8 +112,12 @@ class TestImpatient < Pgtk::Test
       captured = []
       Pgtk::Impatient.new(Pgtk::Spy.new(pool) { |sql, _| captured << sql }, 1.5, /^SELECT 1/).exec('SELECT 1')
       assert(
-        captured.any? { |s| s.match?(/SET LOCAL statement_timeout\s*=\s*300000\b/) },
+        captured.any? { |s| s.match?(/SET statement_timeout\s*=\s*300000\b/) },
         "must set default 300s statement_timeout for excluded queries, got: #{captured.inspect}"
+      )
+      refute(
+        captured.any? { |s| s.include?('SET LOCAL') || s.include?('START TRANSACTION') },
+        "excluded queries must not run inside a transaction, got: #{captured.inspect}"
       )
     end
   end
@@ -127,7 +131,7 @@ class TestImpatient < Pgtk::Test
         end, 1.5, /^SELECT 1/, default: 10
       ).exec('SELECT 1')
       assert(
-        captured.any? { |s| s.match?(/SET LOCAL statement_timeout\s*=\s*10000\b/) },
+        captured.any? { |s| s.match?(/SET statement_timeout\s*=\s*10000\b/) },
         "must set custom default timeout, got: #{captured.inspect}"
       )
     end
@@ -142,9 +146,15 @@ class TestImpatient < Pgtk::Test
         end, 1.5, /^SELECT 1/, default: 0
       ).exec('SELECT 1')
       refute(
-        captured.any? { |s| s.include?('SET LOCAL statement_timeout') },
+        captured.any? { |s| s.include?('statement_timeout') },
         "must not set statement_timeout when default is 0, got: #{captured.inspect}"
       )
+    end
+  end
+
+  def test_runs_excluded_query_outside_transaction
+    fake_pool do |pool|
+      Pgtk::Impatient.new(pool, 1, /^VACUUM/).exec('VACUUM book')
     end
   end
 

--- a/test/test_pool.rb
+++ b/test/test_pool.rb
@@ -128,6 +128,28 @@ class TestPool < Pgtk::Test
     end
   end
 
+  def test_session_runs_without_transaction
+    fake_pool do |pool|
+      pool.session do |s|
+        s.exec('SET statement_timeout = 5000')
+        s.exec('VACUUM book')
+        s.exec('RESET statement_timeout')
+      end
+    end
+  end
+
+  def test_session_returns_block_result
+    fake_pool do |pool|
+      assert_predicate(
+        Integer(
+          pool.session do |s|
+            s.exec('INSERT INTO book (title) VALUES ($1) RETURNING id', ['1984']).first['id']
+          end, 10
+        ), :positive?
+      )
+    end
+  end
+
   def test_logs_sql
     log = Loog::Buffer.new
     fake_pool(log: log) do |pool|


### PR DESCRIPTION
Fixes #416.

## Problem

`Pgtk::Impatient#exec` executed off-list (excluded) queries inside an explicit `@pool.transaction` that issued `SET LOCAL statement_timeout` (introduced in #387 / v0.32.5). That broke statements which cannot run inside a transaction block — most notably `VACUUM` (`VACUUM cannot run inside a transaction block`), but also `REINDEX` and `CREATE INDEX CONCURRENTLY`. The whole point of the off-list is to exempt exactly these statements, so wrapping them in a transaction defeated the feature.

## Fix

Off-list queries now run **without** a transaction:

- A new `Pgtk::Pool#session` primitive grabs a single connection and yields an executor bound to it, **without** issuing `START TRANSACTION`. Statements run on the same connection, so a session-level setting made earlier (e.g. `SET statement_timeout`) stays in effect for the statements that follow. The same delegate is mirrored on `Pgtk::Spy` and `Pgtk::Stash` so the decorator chain keeps working.
- `Impatient#exec` applies the fallback timeout for off-list queries at the **session** level via `SET statement_timeout = <default>` on that single connection, runs the query, then `RESET statement_timeout`. On error the connection is renewed by the pool, so the timeout never leaks onto a pooled connection.
- When `default: 0`, off-list queries run via plain `@pool.exec` with no timeout at all (unchanged behaviour for that case).

The regular (on-list) timeout path is unchanged: it still wraps each query in a tiny transaction with `SET LOCAL statement_timeout` and translates `PG::QueryCanceled` to `TooSlow`.

## Tests

- `test_runs_excluded_query_outside_transaction` — `VACUUM book` through an off-list regex now succeeds (it raised `VACUUM cannot run inside a transaction block` before this fix).
- Updated `test_excluded_still_timed_out` / `test_excluded_custom_default` / `test_excluded_zero_default` to assert the session-level `SET statement_timeout` (not `SET LOCAL`) and that off-list queries never emit `SET LOCAL` / `START TRANSACTION`.
- Added `test_session_runs_without_transaction` and `test_session_returns_block_result` for `Pool#session`.

Note: the integration test suite requires a bootable local PostgreSQL, which couldn't run in the build sandbox (no IPv6 loopback for the `random-port` gem). The off-list routing logic was verified out-of-band against a fake pool/spy, and `rubocop` passes on all changed files; CI will exercise the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nurtxsvEHMNXuUaz8SSNd

---
_Generated by [Claude Code](https://claude.ai/code/session_018nurtxsvEHMNXuUaz8SSNd)_