### PR TITLE
#424: report cache memory footprint in Stash#dump

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ plugins:
   - rubocop-performance
   - rubocop-elegant
 Metrics/ClassLength:
-  Max: 331
+  Max: 341
 Metrics/CyclomaticComplexity:
   Max: 20
 Metrics/PerceivedComplexity:

--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -6,6 +6,7 @@
 require 'concurrent-ruby'
 require 'joined'
 require 'loog'
+require 'objspace'
 require 'tago'
 require_relative '../pgtk'
 
@@ -184,7 +185,7 @@ class Pgtk::Stash
       else
         '  Not launched yet'
       end,
-      "  #{cached} queries cached (#{cached > @cap ? 'above' : 'below'} the cap)",
+      "  #{cached} queries cached (#{cached > @cap ? 'above' : 'below'} the cap), ~#{footprint} bytes of RAM",
       "  #{@stash[:tables].count} tables in cache",
       "  #{list.sum { |a| a[:s] }} stale queries in cache:",
       stale(list),
@@ -324,6 +325,33 @@ class Pgtk::Stash
   def cached
     @entrance.with_read_lock do
       @stash[:queries].values.sum { |kk| kk.values.size }
+    end
+  end
+
+  # Estimate the total heap footprint, in bytes, of everything held in
+  # +@stash[:queries]+.
+  #
+  # The count of cached entries alone is misleading: a single query with many
+  # parameter combinations keeps a distinct +PG::Result+ per combination, and
+  # the +cap+ limits the number of entries, not their weight. This gauge sums
+  # +ObjectSpace.memsize_of+ over each cached entry and its +:ret+, +:params+,
+  # and key strings, so an operator can tell whether the cache is about to
+  # exhaust memory. +Marshal+ is not an option here since neither +PG::Result+
+  # nor +Concurrent::AtomicFixnum+ is marshallable.
+  #
+  # The result is approximate: +memsize_of+ is shallow, so nested contents
+  # (rows inside a +PG::Result+) are only partially accounted for. A rough
+  # order of magnitude is enough.
+  #
+  # @return [Integer] Approximate total bytes of RAM held by the cache
+  def footprint
+    @entrance.with_read_lock do
+      @stash[:queries].sum do |q, kk|
+        ObjectSpace.memsize_of(q) +
+          kk.sum do |params, entry|
+            [params, entry, entry[:ret], entry[:params]].sum { |o| ObjectSpace.memsize_of(o) }
+          end
+      end
     end
   end
 

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -308,6 +308,23 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_dump_reports_memory_footprint
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool)
+      stash.start!
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['My book'])
+      empty = stash.dump[/~(\d+) bytes of RAM/, 1]
+      refute_nil(empty, 'the dump must report the cache RAM footprint')
+      10.times do |i|
+        stash.exec('SELECT id, title FROM book WHERE title = $1', ["My book #{i}"])
+      end
+      assert_operator(
+        Integer(stash.dump[/~(\d+) bytes of RAM/, 1]), :>, Integer(empty),
+        'caching results must grow the reported footprint'
+      )
+    end
+  end
+
   def test_cache_refills
     interval = 0.2
     fake_pool do |pool|


### PR DESCRIPTION
Closes #424.

`Pgtk::Stash#dump` reported the task-pool depth, cached-entry count, table count, and the stale/fresh breakdown — but nothing about how many bytes of RAM the cache actually holds. Entry count alone is misleading: the `cap` limits the *number* of entries, not their *weight*, so a stash quietly holding hundreds of megabytes of `PG::Result` objects looked identical to one holding a few kilobytes.

## Changes

- Added a private `footprint` helper that walks `@stash[:queries]` under the read lock and sums `ObjectSpace.memsize_of` over each cached entry and its `:ret`, `:params`, and key strings (`require 'objspace'`). `Marshal` is not usable here since neither `PG::Result` nor `Concurrent::AtomicFixnum` is marshallable.
- Printed the approximate total (`~N bytes of RAM`) next to the cached count in `body`.
- Bumped `Metrics/ClassLength` in `.rubocop.yml` from 331 to 341 to accommodate the new helper (the limit was pinned to the exact prior class size).

The gauge is intentionally approximate — `memsize_of` is shallow, so a rough order of magnitude is enough to answer "is this cache about to exhaust memory?"

## Testing

- Added `test_dump_reports_memory_footprint`, which asserts the dump reports a footprint and that it grows as results are cached.
- `rubocop` passes clean on the changed source files. The full test suite requires a live PostgreSQL instance, which is unavailable in this environment; the `footprint` summation logic was verified in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01777KEettLPs6eQfN5Ce3yW

---
_Generated by [Claude Code](https://claude.ai/code/session_01777KEettLPs6eQfN5Ce3yW)_