### PR TITLE
#426: add `volatile:` parameter to skip caching for write-heavy tables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ plugins:
   - rubocop-performance
   - rubocop-elegant
 Metrics/ClassLength:
-  Max: 341
+  Max: 343
 Metrics/CyclomaticComplexity:
   Max: 20
 Metrics/PerceivedComplexity:

--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -16,6 +16,10 @@ require_relative '../pgtk'
 # the cache when tables are modified. Read queries are cached while write
 # queries bypass the cache and invalidate related cached entries.
 #
+# Tables that are too write-heavy to benefit from caching can be listed
+# via the +volatile:+ constructor parameter; any read whose FROM/JOIN
+# set touches one of them bypasses the cache entirely.
+#
 # Thread-safe with read-write locking.
 #
 # The implementation is very naive! Use it at your own risk.
@@ -68,11 +72,13 @@ class Pgtk::Stash
   # @param [Float] retirement Interval in seconds between retirement tasks
   # @param [Loog] loog Logger instance
   # @param [Concurrent::ReentrantReadWriteLock] entrance Read-write lock for thread-safe access
+  # @param [Array<String>] volatile Table names that must never be cached
   def initialize(
     pool,
     stash: { queries: {}, tables: {}, table_mod: {}, table_inflight: {} },
     loog: Loog::NULL,
     entrance: Concurrent::ReentrantReadWriteLock.new,
+    volatile: [],
     refill: 16,
     delay: 0,
     maxqueue: 128,
@@ -90,6 +96,7 @@ class Pgtk::Stash
     end
     @loog = loog
     @entrance = entrance
+    @volatile = volatile
     @refill = refill
     @delay = delay
     @maxqueue = maxqueue
@@ -134,7 +141,7 @@ class Pgtk::Stash
     pure = (query.is_a?(Array) ? query.join(' ') : query).gsub(/\s+/, ' ').strip
     if MODS_RE.match?(pure) || (WITH_RE.match?(pure) && ALTS_RE.match?(pure))
       modify(pure, params, result)
-    elsif /(^|\s)pg_[a-z_]+\(/.match?(pure)
+    elsif /(^|\s)pg_[a-z_]+\(/.match?(pure) || (!@volatile.empty? && @volatile.intersect?(pure.scan(READS_RE).flatten))
       @pool.exec(pure, params, result)
     else
       select(pure, params, result)
@@ -147,7 +154,7 @@ class Pgtk::Stash
   # @return [Object] The result of the block
   def transaction
     @pool.transaction do |t|
-      yield(Pgtk::Stash.new(t, stash: @stash, loog: @loog, entrance: @entrance))
+      yield(Pgtk::Stash.new(t, stash: @stash, loog: @loog, entrance: @entrance, volatile: @volatile))
     end
   end
 
@@ -157,7 +164,7 @@ class Pgtk::Stash
   # @return [Object] The result of the block
   def session
     @pool.session do |t|
-      yield(Pgtk::Stash.new(t, stash: @stash, loog: @loog, entrance: @entrance))
+      yield(Pgtk::Stash.new(t, stash: @stash, loog: @loog, entrance: @entrance, volatile: @volatile))
     end
   end
 

--- a/lib/pgtk/stash.rb
+++ b/lib/pgtk/stash.rb
@@ -96,7 +96,7 @@ class Pgtk::Stash
     end
     @loog = loog
     @entrance = entrance
-    @volatile = volatile
+    @volatile = Array(volatile).map(&:to_s).freeze
     @refill = refill
     @delay = delay
     @maxqueue = maxqueue

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -808,6 +808,69 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_volatile_table_is_never_cached
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: ['book'])
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Volatile'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.exec(query, ['Volatile']).then do |first|
+        refute_same(first, stash.exec(query, ['Volatile']), 'a volatile table must never be cached')
+      end
+    end
+  end
+
+  def test_non_volatile_table_still_cached
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: ['invocation'])
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Cacheable'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.exec(query, ['Cacheable']).then do |first|
+        assert_same(first, stash.exec(query, ['Cacheable']), 'a non-volatile table must still be cached')
+      end
+    end
+  end
+
+  def test_volatile_ignores_name_in_string_literal
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: ['book'])
+      stash.exec('DROP TABLE IF EXISTS tmp CASCADE')
+      stash.exec('CREATE TABLE tmp (id INT, title TEXT)')
+      stash.exec("INSERT INTO tmp VALUES (1, 'from book')")
+      query = "SELECT title FROM tmp WHERE title LIKE '%book%'"
+      stash.exec(query).then do |first|
+        assert_same(first, stash.exec(query), 'the volatile name inside a string literal must not disable caching')
+      end
+    end
+  end
+
+  def test_volatile_propagates_into_transaction
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: ['book'])
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Tx'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.transaction do |tx|
+        tx.exec(query, ['Tx']).then do |first|
+          refute_same(first, tx.exec(query, ['Tx']), 'volatile bypass must hold inside a transaction')
+        end
+        true
+      end
+    end
+  end
+
+  def test_volatile_propagates_into_session
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: ['book'])
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Sess'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.session do |s|
+        s.exec(query, ['Sess']).then do |first|
+          refute_same(first, s.exec(query, ['Sess']), 'volatile bypass must hold inside a session')
+        end
+        true
+      end
+    end
+  end
+
   private
 
   def hammer(stash, count, writers, readers, seconds)

--- a/test/test_stash.rb
+++ b/test/test_stash.rb
@@ -871,6 +871,28 @@ class TestStash < Pgtk::Test
     end
   end
 
+  def test_volatile_accepts_symbol_names
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: [:book])
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Sym'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.exec(query, ['Sym']).then do |first|
+        refute_same(first, stash.exec(query, ['Sym']), 'a symbol volatile name must be coerced and honoured')
+      end
+    end
+  end
+
+  def test_volatile_defaults_to_empty_and_caches
+    fake_pool do |pool|
+      stash = Pgtk::Stash.new(pool, volatile: nil)
+      stash.exec('INSERT INTO book (title) VALUES ($1)', ['Nil'])
+      query = 'SELECT title FROM book WHERE title = $1'
+      stash.exec(query, ['Nil']).then do |first|
+        assert_same(first, stash.exec(query, ['Nil']), 'nil volatile must behave like an empty list')
+      end
+    end
+  end
+
   private
 
   def hammer(stash, count, writers, readers, seconds)


### PR DESCRIPTION
Fixes #426.

## What

`Pgtk::Stash` had no way to tell it that a specific table is too write-heavy to be worth caching. For a high-write, high-parameter-cardinality table (e.g. `invocation` in the issue), every write marks all its cached entries stale at once, the refiller never catches up, and the cache yields zero hit benefit while still burning memory and background DB queries.

## Changes

- **New constructor parameter `volatile:`** (defaults to `[]`) — a list of table names that must never be cached.
- **New bypass branch in `exec`**, beside the existing `pg_*()` one: when the query's read-set intersects `volatile`, the query goes straight to `@pool.exec`. The read-set is computed with `pure.scan(READS_RE)` (FROM/JOIN targets) rather than a raw substring match, so a table name appearing inside a string literal or a column name does **not** falsely disable caching (cf #388).
- **Propagation** of `volatile` to the sub-stash built in `transaction` and `session`, so the bypass holds inside transactions and sessions too.
- Bumped `Metrics/ClassLength` max (from 341 to 343) to accommodate the two new body lines.

`Array#intersect?` (Ruby >= 3.2) is used for the check.

## Tests

Added five tests in `test/test_stash.rb`:
- a volatile table is never cached;
- a non-volatile table is still cached when an unrelated table is volatile;
- the volatile name inside a string literal does not disable caching;
- the bypass propagates into `transaction`;
- the bypass propagates into `session`.

Note: the DB-backed test suite could not be executed in the CI sandbox used here because it requires IPv6 loopback to boot PostgreSQL (`Errno::EAFNOSUPPORT` from `random-port`), which fails for the pre-existing tests too. RuboCop passes cleanly, and the read-set/`intersect?` logic was verified standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CGEiAvtu1tdWVspwbB6yj