### PR TITLE
Take statement_timeout from the connection, not from a SET inside a transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,25 @@ end
 ## Query Timeouts with `Pgtk::Impatient`
 
 To prevent queries from running indefinitely, use `Pgtk::Impatient` to enforce
-timeouts on database operations:
+timeouts on database operations.
+The limit itself belongs to the connection: the wire puts `statement_timeout`
+into the startup packet, and the decorator explains what happened when
+PostgreSQL applies it:
 
 ```ruby
 require 'pgtk/impatient'
-# Wrap the pool with a 5-second timeout for all queries
+# Every connection of the pool carries a 5-second limit
+pool = Pgtk::Pool.new(
+  Pgtk::Wire::Env.new('DATABASE_URL', options: '-c statement_timeout=5000'),
+  max: 4
+)
+pool.start!
+# Wrap the pool, telling it about the very same 5 seconds
 impatient = Pgtk::Impatient.new(pool, 5)
 ```
+
+Both numbers must agree, since the connection stops the query, while the
+decorator only reports it.
 
 The impatient decorator ensures queries don't hang your application:
 
@@ -243,31 +255,32 @@ You can exclude specific queries from timeout enforcement using regex patterns:
 impatient = Pgtk::Impatient.new(pool, 2, /^SELECT/, /^VACUUM/)
 ```
 
-Excluded queries are never wrapped in a transaction, because statements such as
-`VACUUM`, `REINDEX`, or `CREATE INDEX CONCURRENTLY` cannot run inside a
-transaction block. Instead, a longer fallback timeout (300 seconds by default,
-configurable via the `default:` argument) is applied at the session level with
-`SET statement_timeout` before the query runs, and reset afterwards. Pass
-`default: 0` to run excluded queries with no timeout at all:
+Excluded queries get a longer fallback timeout (300 seconds by default,
+configurable via the `default:` argument), applied at the session level with
+`SET statement_timeout` before the query runs and reset afterwards. This is how
+statements that legitimately need much longer than a query, such as `VACUUM`,
+`REINDEX`, or `CREATE INDEX CONCURRENTLY`, stay possible. Pass `default: 0` to
+run excluded queries with no timeout at all:
 
 ```ruby
 # Give excluded queries a 60-second fallback timeout
 impatient = Pgtk::Impatient.new(pool, 2, /^VACUUM/, default: 60)
 ```
 
-The timeout is enforced on the server side: each query is wrapped in a tiny
-transaction that issues `SET LOCAL statement_timeout`, and PostgreSQL itself
-terminates the query at the deadline. This guarantees the server-side
-connection slot is freed even when the client cannot deliver a cancellation
-request — for example, behind a transaction-pool PgBouncer that does not
-forward client disconnects to in-flight server queries.
+The limit travels in the startup packet and nowhere else. An in-band
+`SET LOCAL statement_timeout` arrives behind a `START TRANSACTION`, and both of
+them run with no limit in force, which is exactly the hang that `Impatient`
+exists to prevent. A setting from the startup packet is in force from the first
+byte of the first statement, survives a transaction-pooling PgBouncer, and
+frees the server-side connection slot even when the client cannot deliver a
+cancellation request.
 
 Key features:
 
 1. Configurable timeout in seconds for each query
 1. Raises `Pgtk::Impatient::TooSlow` exception when timeout is exceeded
 1. Can exclude queries matching specific patterns from timeout checks
-1. Sets PostgreSQL's `statement_timeout` per query and per transaction,
+1. Sends each query in a single round trip, with the limit already in force,
    so timeouts are enforced server-side and orphan backends do not pile up
 
 ## Query Caching with `Pgtk::Stash`

--- a/lib/pgtk/impatient.rb
+++ b/lib/pgtk/impatient.rb
@@ -12,26 +12,30 @@ require_relative '../pgtk'
 # It ensures that SQL queries don't run indefinitely, which helps prevent application
 # hangs and resource exhaustion when database operations are slow or stalled.
 #
-# This class implements the same interface as Pool but enforces the timeout on the
-# server side, by wrapping each query in a tiny transaction that issues
-# +SET LOCAL statement_timeout+. PostgreSQL itself terminates the query at the
-# deadline, which guarantees that the server-side connection slot is freed even
-# when the client cannot deliver a cancellation request (for example, behind a
-# transaction-pool PgBouncer that does not forward client disconnects to in-flight
-# server queries). On timeout, +TooSlow+ is raised.
+# This class implements the same interface as Pool. The timeout itself is
+# enforced by PostgreSQL, through the +statement_timeout+ that the wire puts
+# into the startup packet of every connection. The limit is in force from the
+# first byte of the first statement, which no in-band +SET+ can achieve: the
+# +SET+ itself, and the +START TRANSACTION+ ahead of it, would travel with no
+# limit at all. Because the setting arrives in the startup packet, it also
+# survives a transaction-pooling PgBouncer, and it frees the server-side
+# connection slot even when the client cannot deliver a cancellation request.
+# When PostgreSQL terminates a query at the deadline, +TooSlow+ is raised here.
 #
 # Queries that match one of the +off+ regular expressions are excluded from
-# this checking. They are never wrapped in a transaction, because some
-# statements (such as +VACUUM+, +REINDEX+, or +CREATE INDEX CONCURRENTLY+)
-# cannot run inside a transaction block. Instead, a session-level
-# +SET statement_timeout+ is applied on the same connection before the query
-# runs (and reset afterwards), using the +default+ fallback timeout. Pass
-# +default: 0+ to run excluded queries with no timeout at all.
+# this checking. They run on a single connection, guarded by a session-level
+# +SET statement_timeout+ with the +default+ fallback timeout, which is reset
+# afterwards. Pass +default: 0+ to run excluded queries with no timeout at all.
+# This is how statements that take much longer than a query, such as +VACUUM+
+# or +REINDEX+, stay possible.
 #
 # Basic usage:
 #
-#   # Create and configure a regular pool
-#   pool = Pgtk::Pool.new(wire, max: 4)
+#   # Create a pool of connections that carry a two-second limit
+#   pool = Pgtk::Pool.new(
+#     Pgtk::Wire::Env.new('DATABASE_URL', options: '-c statement_timeout=2000'),
+#     max: 4
+#   )
 #   pool.start!
 #
 #   # Wrap the pool in an impatient decorator with a 2-second timeout
@@ -69,7 +73,8 @@ class Pgtk::Impatient
   # Constructor.
   #
   # @param [Pgtk::Pool] pool The pool to decorate
-  # @param [Integer] timeout Timeout in seconds for each SQL query
+  # @param [Integer] timeout Timeout in seconds for each SQL query, the same
+  #   one that the connections of the pool carry as +statement_timeout+
   # @param [Array<Regex>] off List of regex to exclude queries from checking
   # @param [Integer] default Fallback timeout in seconds for excluded queries (0 = no timeout)
   def initialize(pool, timeout, *off, default: 300)
@@ -103,18 +108,14 @@ class Pgtk::Impatient
 
   # Execute a SQL query with a server-side timeout.
   #
-  # The query is wrapped in a tiny transaction that issues
-  # +SET LOCAL statement_timeout+, so PostgreSQL itself terminates the query
-  # at the deadline. This guarantees the server-side connection slot is freed
-  # even when the client cannot deliver a cancellation request (for example,
-  # behind a transaction-pool PgBouncer). When the deadline fires, the
-  # underlying +PG::QueryCanceled+ is translated to +TooSlow+.
+  # The query travels alone, in a single round trip, and the limit is the
+  # +statement_timeout+ that the connection already carries. When the deadline
+  # fires, the underlying +PG::QueryCanceled+ is translated to +TooSlow+.
   #
-  # Queries matching one of the +off+ regular expressions bypass this
-  # transaction. They run on a single connection without a transaction block,
-  # guarded by a session-level +SET statement_timeout+ (the +default+ fallback,
-  # reset afterwards) or by no timeout at all when +default+ is zero. This keeps
-  # statements that cannot run inside a transaction, such as +VACUUM+ or
+  # Queries matching one of the +off+ regular expressions are guarded instead
+  # by a session-level +SET statement_timeout+ (the +default+ fallback, reset
+  # afterwards), or by no timeout at all when +default+ is zero. This keeps
+  # statements that need much longer than a query, such as +VACUUM+ or
   # +REINDEX+, working as expected.
   #
   # @param [String, Array] query The SQL query with params inside (possibly)
@@ -124,20 +125,14 @@ class Pgtk::Impatient
   def exec(query, *args)
     sql = query.is_a?(Array) ? query.join(' ') : query
     if @off.any? { |re| re.match?(sql) }
-      ms = Integer(@default * 1000)
-      return @pool.exec(sql, *args) if ms.zero?
       return @pool.session do |t|
-        t.exec("SET statement_timeout = #{ms}")
+        t.exec("SET statement_timeout = #{Integer(@default * 1000)}")
         t.exec(sql, *args).tap { t.exec('RESET statement_timeout') }
       end
     end
     start = Time.now
-    ms = [Integer(@timeout * 1000), 1].max
     begin
-      @pool.transaction do |t|
-        t.exec("SET LOCAL statement_timeout = #{ms}")
-        t.exec(sql, *args)
-      end
+      @pool.exec(sql, *args)
     rescue PG::QueryCanceled
       raise(
         TooSlow, [

--- a/lib/pgtk/impatient/too_slow.rb
+++ b/lib/pgtk/impatient/too_slow.rb
@@ -8,9 +8,9 @@ require_relative '../../pgtk'
 class Pgtk::Impatient; end
 
 # Raised by Pgtk::Impatient#exec when the query takes longer than the
-# configured timeout. The deadline is enforced server-side via
-# +SET LOCAL statement_timeout+, so the underlying +PG::QueryCanceled+
-# is translated into this error for the caller.
+# configured timeout. The deadline is enforced server-side, by the
+# +statement_timeout+ of the connection, so the underlying
+# +PG::QueryCanceled+ is translated into this error for the caller.
 #
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -74,9 +74,9 @@ class Pgtk::Test < Minitest::Test
     end
   end
 
-  def fake_pool(size = 1, log: Loog::NULL)
+  def fake_pool(size = 1, log: Loog::NULL, **opts)
     fake_config do |f|
-      pool = Pgtk::Pool.new(Pgtk::Wire::Yaml.new(f), max: size, log: log)
+      pool = Pgtk::Pool.new(Pgtk::Wire::Yaml.new(f, **opts), max: size, log: log)
       pool.start!
       yield(pool)
     end

--- a/test/test_impatient.rb
+++ b/test/test_impatient.rb
@@ -33,9 +33,17 @@ class TestImpatient < Pgtk::Test
   end
 
   def test_interrupts
-    fake_pool do |pool|
+    fake_pool(options: '-c statement_timeout=10') do |pool|
       assert_raises(Pgtk::Impatient::TooSlow) do
         Pgtk::Impatient.new(pool, 0.01).exec(['SELECT COUNT(*)', 'FROM generate_series(1, 1000000) AS a'])
+      end
+    end
+  end
+
+  def test_interrupts_query_with_arguments
+    fake_pool(options: '-c statement_timeout=50') do |pool|
+      assert_raises(Pgtk::Impatient::TooSlow) do
+        Pgtk::Impatient.new(pool, 0.05).exec('SELECT pg_sleep($1)', [5])
       end
     end
   end
@@ -96,14 +104,11 @@ class TestImpatient < Pgtk::Test
     end
   end
 
-  def test_sets_server_side_timeout_per_query
+  def test_sends_query_alone
     fake_pool do |pool|
       captured = []
       Pgtk::Impatient.new(Pgtk::Spy.new(pool) { |sql, _| captured << sql }, 1.5).exec('SELECT 1')
-      assert(
-        captured.any? { |s| s.match?(/SET LOCAL statement_timeout\s*=\s*\d+/) },
-        "must set statement_timeout per query, got: #{captured.inspect}"
-      )
+      assert_equal(['SELECT 1'], captured, "must send no statement ahead of the query: #{captured.inspect}")
     end
   end
 
@@ -145,9 +150,9 @@ class TestImpatient < Pgtk::Test
           captured << sql
         end, 1.5, /^SELECT 1/, default: 0
       ).exec('SELECT 1')
-      refute(
-        captured.any? { |s| s.include?('statement_timeout') },
-        "must not set statement_timeout when default is 0, got: #{captured.inspect}"
+      assert(
+        captured.any? { |s| s.match?(/SET statement_timeout\s*=\s*0\b/) },
+        "must lift the limit of the connection when default is 0, got: #{captured.inspect}"
       )
     end
   end
@@ -159,7 +164,7 @@ class TestImpatient < Pgtk::Test
   end
 
   def test_does_not_leave_orphan_backend_after_timeout
-    fake_pool(2) do |pool|
+    fake_pool(2, options: '-c statement_timeout=300') do |pool|
       tag = SecureRandom.hex(8)
       sql = "SELECT pg_sleep(30) /* #{tag} */"
       assert_raises(Pgtk::Impatient::TooSlow) do


### PR DESCRIPTION
`Pgtk::Impatient#exec` used to wrap every query in a transaction and issue `SET LOCAL statement_timeout` inside it. Now it sends the query alone, in one round trip, and relies on the `statement_timeout` that the connection already carries from its startup packet — configured on the wire with `options: '-c statement_timeout=<ms>'`.

The old scheme put two statements ahead of the query, and both of them travelled with no limit in force: `START TRANSACTION` from the pool, then the `SET` itself. So the decorator meant to bound a query could hang on the statements it added, which is what #439 reports from production. A setting delivered in the startup packet is in force from the first byte of the first statement, and it survives a transaction-pooling PgBouncer too. Excluded queries (the `off` regexes) keep their session-level fallback, and `default: 0` now sets `statement_timeout = 0` explicitly, since otherwise the connection-level limit would apply to a `VACUUM`.

One thing for the reviewer to weigh: the timeout now lives in two places — the wire and the decorator — and they have to agree. If you want sugar for that, say a `timeout:` argument on the wires that renders the `-c` flag, I am happy to add it here or in a follow-up. README and docblocks are updated, and `Impatient#transaction` is left alone.

Closes #439